### PR TITLE
Add rain indicator for weeks with a non-zero chance of rain

### DIFF
--- a/iracing-api/parse-data.ts
+++ b/iracing-api/parse-data.ts
@@ -238,6 +238,7 @@ const isLegacy = (name: string) => {
           name: week.track.track_name,
           config: week.track.config_name,
         },
+        rainChance: week.weather?.weather_summary?.precip_chance ?? 0,
       })),
     }))
     .reduce((acc, curr) => ({ ...acc, [curr.id]: curr }), {});

--- a/src/components/season/season-cars-popover.tsx
+++ b/src/components/season/season-cars-popover.tsx
@@ -1,4 +1,4 @@
-import { HStack, StackProps } from "@chakra-ui/react";
+import { Box, HStack, StackProps } from "@chakra-ui/react";
 import { faCar, faCaretDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import ContentPopover from "../content/content-popover";
@@ -12,23 +12,25 @@ import {
 function SeasonCarsPopover({ cars, ...rest }: StackProps & { cars: number[] }) {
   return (
     <PopoverRoot lazyMount unmountOnExit>
-      <PopoverTrigger asChild>
-        <HStack
-          gap={1}
-          justifyContent={"center"}
-          cursor={"pointer"}
-          position={"absolute"}
-          right={1}
-          top={1}
-          px={2}
-          rounded={"4px"}
-          bgColor={"bg.muted"}
-          {...rest}
-        >
-          <FontAwesomeIcon icon={faCar} />
-          {cars.length}
-          <FontAwesomeIcon icon={faCaretDown} />
-        </HStack>
+      <PopoverTrigger>
+        <Box>
+          <HStack
+            gap={1}
+            justifyContent={"center"}
+            cursor={"pointer"}
+            position={"absolute"}
+            right={1}
+            top={1}
+            px={2}
+            rounded={"4px"}
+            bgColor={"bg.muted"}
+            {...rest}
+          >
+            <FontAwesomeIcon icon={faCar} />
+            {cars.length}
+            <FontAwesomeIcon icon={faCaretDown} />
+          </HStack>
+        </Box>
       </PopoverTrigger>
       <PopoverContent p={2}>
         <PopoverArrow />

--- a/src/components/season/season-settings-popover.tsx
+++ b/src/components/season/season-settings-popover.tsx
@@ -4,6 +4,7 @@ import {
   setSeasonShowCheckboxes,
   setSeasonShowOwned,
   setSeasonShowParticipation,
+  setSeasonShowRain,
   setSeasonShowReorder,
   setSeasonShowThisWeek,
   setSeasonShowTrackConfig,
@@ -25,6 +26,7 @@ function SeasonSettingsPopover() {
     seasonShowWishlist,
     seasonShowOwned,
     seasonShowParticipation,
+    seasonShowRain,
   } = useUi();
 
   const settingsList = [
@@ -91,6 +93,13 @@ function SeasonSettingsPopover() {
         "Either series you have enough tracks to get reward should be colored",
       checked: seasonShowParticipation,
       setChecked: setSeasonShowParticipation,
+    },
+    {
+      id: "rain",
+      text: "Show rain",
+      tooltip: "Show rain indicators for tracks with chance of rain",
+      checked: seasonShowRain,
+      setChecked: setSeasonShowRain,
     },
   ];
 

--- a/src/components/season/season-table-header-participation.tsx
+++ b/src/components/season/season-table-header-participation.tsx
@@ -19,12 +19,17 @@ function SeasonTableHeaderParticipation({
 
   const { numberOfTracks, tracksNeeded, enoughTracks } = useMemo(() => {
     const filteredTracks = Object.fromEntries(
-      Object.entries(seriesTracks).filter(([key]) => !key.includes("_cars")),
+      Object.entries(seriesTracks).filter(
+        ([key]) => !key.includes("_cars") && !key.includes("_rainChance")
+      ),
     );
 
     const tracks = Object.values(filteredTracks).map(
-      (trackId) => TRACKS_JSON[trackId.toString() as keyof typeof TRACKS_JSON],
-    ) as TContent[];
+      (trackId) => {
+        const track = TRACKS_JSON[trackId.toString() as keyof typeof TRACKS_JSON];
+        return track;
+      }
+    ).filter(Boolean) as TContent[];
 
     const tracksNeeded = Math.ceil(tracks.length * PARTICIPATION_THRESHOLD);
 

--- a/src/components/season/season-table-row-cell.tsx
+++ b/src/components/season/season-table-row-cell.tsx
@@ -1,5 +1,5 @@
 import { useUi } from "@/store/ui";
-import { Text } from "@chakra-ui/react";
+import { Box, Flex, Text } from "@chakra-ui/react";
 import React from "react";
 import ContentCheckbox from "../content/content-checkbox";
 import SeasonTableCarsPopover from "./season-table-cars-popover";
@@ -40,11 +40,17 @@ function SeasonTableRowCell({
     seasonHighlight,
     seasonShowWishlist,
     seasonShowOwned,
+    seasonShowRain,
   } = useUi();
 
   const cars: number[] =
     seriesDateMap?.[seriesId as keyof typeof seriesDateMap]?.[`${date}_cars`] ||
     [];
+  
+  const rainChance: number =
+    seriesDateMap?.[seriesId as keyof typeof seriesDateMap]?.[`${date}_rainChance`] ||
+    0;
+
   const color = {
     _dark: free
       ? "green.400"
@@ -103,43 +109,58 @@ function SeasonTableRowCell({
       bgColor={seasonHighlight && highlight ? bgColorHighlight : bgColor}
       color={color}
     >
-      <Text
-        userSelect={"none"}
-        textAlign={"center"}
-        lineClamp="3"
-        lineHeight={"18px"}
-      >
-        {name}
-      </Text>
-      {seasonShowTrackConfig && config && (
+      {seasonShowRain && rainChance > 0 && (
+        <Box 
+          position="absolute" 
+          top="2px" 
+          right="2px"
+          fontSize="14px"
+          lineHeight="1"
+          zIndex="1"
+          title={`${rainChance}% chance of rain`}
+        >
+          💧
+        </Box>
+      )}
+      <Flex direction="column" position="relative">
         <Text
           userSelect={"none"}
           textAlign={"center"}
           lineClamp="3"
-          lineHeight={"12px"}
-          fontSize={"10px"}
-          pt="2px"
+          lineHeight={"18px"}
         >
-          ({config})
+          {name}
         </Text>
-      )}
-      {seasonShowCarsDropdown && cars.length > 0 && (
-        <SeasonTableCarsPopover cars={cars} />
-      )}
-      {seasonShowCheckboxes && (
-        <ContentCheckbox
-          size={"xs"}
-          position={"absolute"}
-          left={1}
-          top={1}
-          content={"tracks"}
-          sku={sku}
-          contentId={id}
-          free={free}
-          owned={owned}
-          wish={wish}
-        />
-      )}
+        {seasonShowTrackConfig && config && (
+          <Text
+            userSelect={"none"}
+            textAlign={"center"}
+            lineClamp="3"
+            lineHeight={"12px"}
+            fontSize={"10px"}
+            pt="2px"
+          >
+            ({config})
+          </Text>
+        )}
+        {seasonShowCarsDropdown && cars.length > 0 && (
+          <SeasonTableCarsPopover cars={cars} />
+        )}
+        {seasonShowCheckboxes && (
+          <ContentCheckbox
+            size={"xs"}
+            position={"absolute"}
+            left={1}
+            top={1}
+            content={"tracks"}
+            sku={sku}
+            contentId={id}
+            free={free}
+            owned={owned}
+            wish={wish}
+          />
+        )}
+      </Flex>
     </SortableColumnCell>
   );
 }

--- a/src/components/season/useSeason.ts
+++ b/src/components/season/useSeason.ts
@@ -7,6 +7,7 @@ type TWeek = {
   date: string;
   track: { id: number; name: string };
   cars?: { id: number; name: string }[];
+  rainChance?: number;
 };
 
 export function getPreviousTuesday(date: string): string {
@@ -59,6 +60,7 @@ const useSeason = () => {
             return {
               ...acc2,
               [date]: curr2.track.id,
+              [`${date}_rainChance`]: curr2.rainChance || 0,
               ...(series.switching
                 ? { [`${date}_cars`]: curr2.cars?.map((c) => c.id) }
                 : {}),

--- a/src/ir-data/series.json
+++ b/src/ir-data/series.json
@@ -27,7 +27,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -36,7 +37,8 @@
           "id": 17,
           "name": "Lanier National Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -45,7 +47,8 @@
           "id": 366,
           "name": "North Wilkesboro Speedway",
           "config": "1987"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -53,7 +56,8 @@
         "track": {
           "id": 15,
           "name": "Concord Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -61,7 +65,8 @@
         "track": {
           "id": 271,
           "name": "The Bullring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -69,7 +74,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -78,7 +84,8 @@
           "id": 335,
           "name": "Charlotte Motor Speedway",
           "config": "Legends Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -86,7 +93,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -94,7 +102,8 @@
         "track": {
           "id": 256,
           "name": "Southern National Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -102,7 +111,8 @@
         "track": {
           "id": 248,
           "name": "Five Flags Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -110,7 +120,8 @@
         "track": {
           "id": 201,
           "name": "Langley Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -119,7 +130,8 @@
           "id": 352,
           "name": "Lime Rock Park",
           "config": "Classic"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -150,7 +162,8 @@
         "track": {
           "id": 271,
           "name": "The Bullring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -158,7 +171,8 @@
         "track": {
           "id": 256,
           "name": "Southern National Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -166,7 +180,8 @@
         "track": {
           "id": 94,
           "name": "The Milwaukee Mile"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -174,7 +189,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -182,7 +198,8 @@
         "track": {
           "id": 414,
           "name": "Hickory Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -191,7 +208,8 @@
           "id": 17,
           "name": "Lanier National Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -199,7 +217,8 @@
         "track": {
           "id": 286,
           "name": "Myrtle Beach Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -208,7 +227,8 @@
           "id": 366,
           "name": "North Wilkesboro Speedway",
           "config": "1987"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -216,7 +236,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -225,7 +246,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -233,7 +255,8 @@
         "track": {
           "id": 201,
           "name": "Langley Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -241,7 +264,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -273,7 +297,8 @@
           "id": 185,
           "name": "Oulton Park Circuit",
           "config": "Intl w/no Chicanes"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -282,7 +307,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -291,7 +317,8 @@
           "id": 166,
           "name": "Okayama International Circuit",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -300,7 +327,8 @@
           "id": 319,
           "name": "Detroit Grand Prix at Belle Isle",
           "config": "Belle Isle"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -309,7 +337,8 @@
           "id": 466,
           "name": "Virginia International Raceway",
           "config": "Grand Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -318,7 +347,8 @@
           "id": 145,
           "name": "Brands Hatch Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -327,7 +357,8 @@
           "id": 297,
           "name": "Snetterton Circuit",
           "config": "300"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -336,7 +367,8 @@
           "id": 98,
           "name": "Sonoma Raceway",
           "config": "NASCAR Long"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -345,7 +377,8 @@
           "id": 9,
           "name": "Summit Point Raceway",
           "config": "Summit Point Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -353,7 +386,8 @@
         "track": {
           "id": 521,
           "name": "Sachsenring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -362,7 +396,8 @@
           "id": 350,
           "name": "Charlotte Motor Speedway",
           "config": "Roval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -370,7 +405,8 @@
         "track": {
           "id": 219,
           "name": "Mount Panorama Circuit"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -401,7 +437,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -409,7 +446,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -418,7 +456,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -426,7 +465,8 @@
         "track": {
           "id": 414,
           "name": "Hickory Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -435,7 +475,8 @@
           "id": 17,
           "name": "Lanier National Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -444,7 +485,8 @@
           "id": 11,
           "name": "Stafford Motor Speedway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -453,7 +495,8 @@
           "id": 493,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Asphalt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -461,7 +504,8 @@
         "track": {
           "id": 15,
           "name": "Concord Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -469,7 +513,8 @@
         "track": {
           "id": 286,
           "name": "Myrtle Beach Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -477,7 +522,8 @@
         "track": {
           "id": 256,
           "name": "Southern National Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -485,7 +531,8 @@
         "track": {
           "id": 201,
           "name": "Langley Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -493,7 +540,8 @@
         "track": {
           "id": 271,
           "name": "The Bullring"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -527,7 +575,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -536,7 +585,8 @@
           "id": 447,
           "name": "Atlanta Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -545,7 +595,8 @@
           "id": 225,
           "name": "Auto Club Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -554,7 +605,8 @@
           "id": 231,
           "name": "Circuit of the Americas",
           "config": "West"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -563,7 +615,8 @@
           "id": 103,
           "name": "Las Vegas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -572,7 +625,8 @@
           "id": 20,
           "name": "Homestead Miami Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -580,7 +634,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -588,7 +643,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -597,7 +653,8 @@
           "id": 365,
           "name": "Bristol Motor Speedway",
           "config": "Single Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -606,7 +663,8 @@
           "id": 203,
           "name": "Rockingham Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -614,7 +672,8 @@
         "track": {
           "id": 162,
           "name": "Dover Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -623,7 +682,8 @@
           "id": 357,
           "name": "Texas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -632,7 +692,8 @@
           "id": 214,
           "name": "Kansas Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 13,
@@ -641,7 +702,8 @@
           "id": 366,
           "name": "North Wilkesboro Speedway",
           "config": "1987"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 14,
@@ -650,7 +712,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 15,
@@ -658,7 +721,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 16,
@@ -666,7 +730,8 @@
         "track": {
           "id": 276,
           "name": "Michigan International Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 17,
@@ -675,7 +740,8 @@
           "id": 169,
           "name": "Iowa Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 18,
@@ -683,7 +749,8 @@
         "track": {
           "id": 277,
           "name": "Pocono Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 19,
@@ -692,7 +759,8 @@
           "id": 353,
           "name": "Lime Rock Park",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 20,
@@ -701,7 +769,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 21,
@@ -710,7 +779,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 22,
@@ -719,7 +789,8 @@
           "id": 237,
           "name": "World Wide Technology Raceway (Gateway)",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 23,
@@ -728,7 +799,8 @@
           "id": 232,
           "name": "Lucas Oil Indianapolis Raceway Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 24,
@@ -737,7 +809,8 @@
           "id": 371,
           "name": "Kentucky Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 25,
@@ -746,7 +819,8 @@
           "id": 433,
           "name": "Watkins Glen International",
           "config": "Cup"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 26,
@@ -754,7 +828,8 @@
         "track": {
           "id": 31,
           "name": "Richmond Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 27,
@@ -762,7 +837,8 @@
         "track": {
           "id": 94,
           "name": "The Milwaukee Mile"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 28,
@@ -770,7 +846,8 @@
         "track": {
           "id": 115,
           "name": "Darlington Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 29,
@@ -779,7 +856,8 @@
           "id": 53,
           "name": "Atlanta Motor Speedway",
           "config": "Oval - 2008"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 30,
@@ -788,7 +866,8 @@
           "id": 365,
           "name": "Bristol Motor Speedway",
           "config": "Single Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 31,
@@ -797,7 +876,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 32,
@@ -806,7 +886,8 @@
           "id": 214,
           "name": "Kansas Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 33,
@@ -815,7 +896,8 @@
           "id": 350,
           "name": "Charlotte Motor Speedway",
           "config": "Roval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 34,
@@ -823,7 +905,8 @@
         "track": {
           "id": 123,
           "name": "Chicagoland Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 35,
@@ -831,7 +914,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 36,
@@ -839,7 +923,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 37,
@@ -848,7 +933,8 @@
           "id": 419,
           "name": "Phoenix Raceway",
           "config": "Oval w/open dogleg"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -880,7 +966,8 @@
           "id": 214,
           "name": "Kansas Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -889,7 +976,8 @@
           "id": 493,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Asphalt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -898,7 +986,8 @@
           "id": 374,
           "name": "Nashville Fairgrounds Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -906,7 +995,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -914,7 +1004,8 @@
         "track": {
           "id": 190,
           "name": "New Smyrna Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -923,7 +1014,8 @@
           "id": 518,
           "name": "Oswego Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -932,7 +1024,8 @@
           "id": 101,
           "name": "Bristol Motor Speedway",
           "config": "Dual Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -941,7 +1034,8 @@
           "id": 237,
           "name": "World Wide Technology Raceway (Gateway)",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -950,7 +1044,8 @@
           "id": 232,
           "name": "Lucas Oil Indianapolis Raceway Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -959,7 +1054,8 @@
           "id": 433,
           "name": "Watkins Glen International",
           "config": "Cup"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -968,7 +1064,8 @@
           "id": 453,
           "name": "Indianapolis Motor Speedway",
           "config": "Open Wheel Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -976,7 +1073,8 @@
         "track": {
           "id": 115,
           "name": "Darlington Raceway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -1010,7 +1108,8 @@
           "id": 20,
           "name": "Homestead Miami Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -1018,7 +1117,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -1026,7 +1126,8 @@
         "track": {
           "id": 115,
           "name": "Darlington Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -1035,7 +1136,8 @@
           "id": 365,
           "name": "Bristol Motor Speedway",
           "config": "Single Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -1044,7 +1146,8 @@
           "id": 103,
           "name": "Las Vegas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -1052,7 +1155,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -1061,7 +1165,8 @@
           "id": 357,
           "name": "Texas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -1070,7 +1175,8 @@
           "id": 214,
           "name": "Kansas Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -1079,7 +1185,8 @@
           "id": 371,
           "name": "Kentucky Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -1088,7 +1195,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -1096,7 +1204,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -1104,7 +1213,8 @@
         "track": {
           "id": 276,
           "name": "Michigan International Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -1138,7 +1248,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -1147,7 +1258,8 @@
           "id": 447,
           "name": "Atlanta Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -1156,7 +1268,8 @@
           "id": 231,
           "name": "Circuit of the Americas",
           "config": "West"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -1165,7 +1278,8 @@
           "id": 419,
           "name": "Phoenix Raceway",
           "config": "Oval w/open dogleg"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -1174,7 +1288,8 @@
           "id": 103,
           "name": "Las Vegas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -1183,7 +1298,8 @@
           "id": 20,
           "name": "Homestead Miami Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -1191,7 +1307,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -1199,7 +1316,8 @@
         "track": {
           "id": 115,
           "name": "Darlington Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -1208,7 +1326,8 @@
           "id": 365,
           "name": "Bristol Motor Speedway",
           "config": "Single Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -1217,7 +1336,8 @@
           "id": 203,
           "name": "Rockingham Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -1225,7 +1345,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -1234,7 +1355,8 @@
           "id": 357,
           "name": "Texas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -1243,7 +1365,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 13,
@@ -1251,7 +1374,8 @@
         "track": {
           "id": 31,
           "name": "Richmond Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 14,
@@ -1260,7 +1384,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 15,
@@ -1268,7 +1393,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 16,
@@ -1277,7 +1403,8 @@
           "id": 374,
           "name": "Nashville Fairgrounds Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 17,
@@ -1286,7 +1413,8 @@
           "id": 225,
           "name": "Auto Club Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 18,
@@ -1294,7 +1422,8 @@
         "track": {
           "id": 277,
           "name": "Pocono Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 19,
@@ -1303,7 +1432,8 @@
           "id": 447,
           "name": "Atlanta Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 20,
@@ -1312,7 +1442,8 @@
           "id": 483,
           "name": "Chicago Street Course",
           "config": "2023 Cup"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 21,
@@ -1321,7 +1452,8 @@
           "id": 48,
           "name": "Sonoma Raceway",
           "config": "NASCAR Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 22,
@@ -1329,7 +1461,8 @@
         "track": {
           "id": 162,
           "name": "Dover Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 23,
@@ -1338,7 +1471,8 @@
           "id": 522,
           "name": "Indianapolis Motor Speedway",
           "config": "NASCAR Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 24,
@@ -1347,7 +1481,8 @@
           "id": 169,
           "name": "Iowa Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 25,
@@ -1356,7 +1491,8 @@
           "id": 433,
           "name": "Watkins Glen International",
           "config": "Cup"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 26,
@@ -1364,7 +1500,8 @@
         "track": {
           "id": 276,
           "name": "Michigan International Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 27,
@@ -1373,7 +1510,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 28,
@@ -1382,7 +1520,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 29,
@@ -1391,7 +1530,8 @@
           "id": 237,
           "name": "World Wide Technology Raceway (Gateway)",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 30,
@@ -1400,7 +1540,8 @@
           "id": 365,
           "name": "Bristol Motor Speedway",
           "config": "Single Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 31,
@@ -1409,7 +1550,8 @@
           "id": 232,
           "name": "Lucas Oil Indianapolis Raceway Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 32,
@@ -1418,7 +1560,8 @@
           "id": 214,
           "name": "Kansas Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 33,
@@ -1427,7 +1570,8 @@
           "id": 350,
           "name": "Charlotte Motor Speedway",
           "config": "Roval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 34,
@@ -1436,7 +1580,8 @@
           "id": 103,
           "name": "Las Vegas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 35,
@@ -1444,7 +1589,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 36,
@@ -1452,7 +1598,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 37,
@@ -1461,7 +1608,8 @@
           "id": 419,
           "name": "Phoenix Raceway",
           "config": "Oval w/open dogleg"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -1492,7 +1640,8 @@
         "track": {
           "id": 489,
           "name": "Circuit de Lédenon"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -1501,7 +1650,8 @@
           "id": 463,
           "name": "Circuit de Nevers Magny-Cours",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -1510,7 +1660,8 @@
           "id": 526,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Bike"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -1518,7 +1669,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -1527,7 +1679,8 @@
           "id": 166,
           "name": "Okayama International Circuit",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -1536,7 +1689,8 @@
           "id": 233,
           "name": "Donington Park Racing Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -1545,7 +1699,8 @@
           "id": 403,
           "name": "Red Bull Ring",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -1553,7 +1708,8 @@
         "track": {
           "id": 219,
           "name": "Mount Panorama Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -1561,7 +1717,8 @@
         "track": {
           "id": 413,
           "name": "Hungaroring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -1570,7 +1727,8 @@
           "id": 105,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -1579,7 +1737,8 @@
           "id": 343,
           "name": "Silverstone Circuit",
           "config": "National"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -1588,7 +1747,8 @@
           "id": 449,
           "name": "Motorsport Arena Oschersleben",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -1620,7 +1780,8 @@
           "id": 18,
           "name": "Road America",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -1629,7 +1790,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -1638,7 +1800,8 @@
           "id": 244,
           "name": "Autodromo Nazionale Monza",
           "config": "GP without first chicane"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -1647,7 +1810,8 @@
           "id": 524,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Classic Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -1656,7 +1820,8 @@
           "id": 229,
           "name": "Circuit of the Americas",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -1665,7 +1830,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -1673,7 +1839,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -1681,7 +1848,8 @@
         "track": {
           "id": 218,
           "name": "Circuit Gilles Villeneuve"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -1690,7 +1858,8 @@
           "id": 498,
           "name": "Autodromo Internazionale del Mugello",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -1699,7 +1868,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -1708,7 +1878,8 @@
           "id": 200,
           "name": "Circuit Zolder",
           "config": "Alternate"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -1716,7 +1887,8 @@
         "track": {
           "id": 532,
           "name": "Thruxton Circuit"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -1748,7 +1920,8 @@
           "id": 255,
           "name": "Nürburgring Grand-Prix-Strecke",
           "config": "BES/WEC"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -1757,7 +1930,8 @@
           "id": 18,
           "name": "Road America",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -1765,7 +1939,8 @@
         "track": {
           "id": 144,
           "name": "Canadian Tire Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -1774,7 +1949,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -1783,7 +1959,8 @@
           "id": 498,
           "name": "Autodromo Internazionale del Mugello",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -1792,7 +1969,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -1800,7 +1978,8 @@
         "track": {
           "id": 152,
           "name": "Phillip Island Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -1809,7 +1988,8 @@
           "id": 185,
           "name": "Oulton Park Circuit",
           "config": "Intl w/no Chicanes"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -1817,7 +1997,8 @@
         "track": {
           "id": 218,
           "name": "Circuit Gilles Villeneuve"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -1826,7 +2007,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -1834,7 +2016,8 @@
         "track": {
           "id": 219,
           "name": "Mount Panorama Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -1843,7 +2026,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -1875,7 +2059,8 @@
           "id": 374,
           "name": "Nashville Fairgrounds Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -1883,7 +2068,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -1892,7 +2078,8 @@
           "id": 161,
           "name": "Thompson Speedway Motorsports Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -1901,7 +2088,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -1909,7 +2097,8 @@
         "track": {
           "id": 414,
           "name": "Hickory Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -1917,7 +2106,8 @@
         "track": {
           "id": 271,
           "name": "The Bullring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -1926,7 +2116,8 @@
           "id": 11,
           "name": "Stafford Motor Speedway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -1934,7 +2125,8 @@
         "track": {
           "id": 201,
           "name": "Langley Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -1943,7 +2135,8 @@
           "id": 518,
           "name": "Oswego Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -1952,7 +2145,8 @@
           "id": 366,
           "name": "North Wilkesboro Speedway",
           "config": "1987"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -1960,7 +2154,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -1969,7 +2164,8 @@
           "id": 493,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Asphalt Track"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -2003,7 +2199,8 @@
           "id": 20,
           "name": "Homestead Miami Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -2011,7 +2208,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -2019,7 +2217,8 @@
         "track": {
           "id": 115,
           "name": "Darlington Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -2028,7 +2227,8 @@
           "id": 365,
           "name": "Bristol Motor Speedway",
           "config": "Single Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -2037,7 +2237,8 @@
           "id": 203,
           "name": "Rockingham Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -2045,7 +2246,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -2054,7 +2256,8 @@
           "id": 357,
           "name": "Texas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -2063,7 +2266,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -2071,7 +2275,8 @@
         "track": {
           "id": 31,
           "name": "Richmond Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -2080,7 +2285,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -2088,7 +2294,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -2097,7 +2304,8 @@
           "id": 374,
           "name": "Nashville Fairgrounds Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -2132,7 +2340,8 @@
           "id": 298,
           "name": "Snetterton Circuit",
           "config": "200"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -2141,7 +2350,8 @@
           "id": 481,
           "name": "Willow Springs International Raceway",
           "config": "Big Willow"
-        }
+        },
+        "rainChance": 47
       },
       {
         "weekNum": 2,
@@ -2150,7 +2360,8 @@
           "id": 350,
           "name": "Charlotte Motor Speedway",
           "config": "Roval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -2159,7 +2370,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -2168,7 +2380,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -2176,7 +2389,8 @@
         "track": {
           "id": 144,
           "name": "Canadian Tire Motorsports Park"
-        }
+        },
+        "rainChance": 34
       },
       {
         "weekNum": 6,
@@ -2185,7 +2399,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -2194,7 +2409,8 @@
           "id": 1,
           "name": "[Legacy] Lime Rock Park - 2008",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -2202,7 +2418,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -2211,7 +2428,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 47
       },
       {
         "weekNum": 10,
@@ -2220,7 +2438,8 @@
           "id": 21,
           "name": "Homestead Miami Speedway",
           "config": "Road Course A"
-        }
+        },
+        "rainChance": 30
       },
       {
         "weekNum": 11,
@@ -2229,7 +2448,8 @@
           "id": 449,
           "name": "Motorsport Arena Oschersleben",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -2262,7 +2482,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -2271,7 +2492,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -2280,7 +2502,8 @@
           "id": 447,
           "name": "Atlanta Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -2288,7 +2511,8 @@
         "track": {
           "id": 276,
           "name": "Michigan International Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -2297,7 +2521,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -2306,7 +2531,8 @@
           "id": 225,
           "name": "Auto Club Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -2314,7 +2540,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -2323,7 +2550,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -2332,7 +2560,8 @@
           "id": 447,
           "name": "Atlanta Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -2340,7 +2569,8 @@
         "track": {
           "id": 276,
           "name": "Michigan International Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -2348,7 +2578,8 @@
         "track": {
           "id": 384,
           "name": "iRacing Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -2357,7 +2588,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -2366,7 +2598,8 @@
           "id": 245,
           "name": "Autodromo Nazionale Monza",
           "config": "Oval - Left turning"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -2398,7 +2631,8 @@
           "id": 169,
           "name": "Iowa Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -2406,7 +2640,8 @@
         "track": {
           "id": 248,
           "name": "Five Flags Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -2414,7 +2649,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -2423,7 +2659,8 @@
           "id": 23,
           "name": "Irwindale Speedway",
           "config": "Outer"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -2432,7 +2669,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -2441,7 +2679,8 @@
           "id": 518,
           "name": "Oswego Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -2450,7 +2689,8 @@
           "id": 374,
           "name": "Nashville Fairgrounds Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -2459,7 +2699,8 @@
           "id": 17,
           "name": "Lanier National Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -2468,7 +2709,8 @@
           "id": 232,
           "name": "Lucas Oil Indianapolis Raceway Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -2477,7 +2719,8 @@
           "id": 500,
           "name": "Slinger Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -2485,7 +2728,8 @@
         "track": {
           "id": 94,
           "name": "The Milwaukee Mile"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -2493,7 +2737,8 @@
         "track": {
           "id": 256,
           "name": "Southern National Motorsports Park"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -2525,7 +2770,8 @@
           "id": 121,
           "name": "[Legacy] Texas Motor Speedway - 2009",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -2533,7 +2779,8 @@
         "track": {
           "id": 276,
           "name": "Michigan International Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -2542,7 +2789,8 @@
           "id": 237,
           "name": "World Wide Technology Raceway (Gateway)",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -2550,7 +2798,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -2559,7 +2808,8 @@
           "id": 447,
           "name": "Atlanta Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -2568,7 +2818,8 @@
           "id": 104,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -2577,7 +2828,8 @@
           "id": 40,
           "name": "[Legacy] Charlotte Motor Speedway - 2008",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -2586,7 +2838,8 @@
           "id": 453,
           "name": "Indianapolis Motor Speedway",
           "config": "Open Wheel Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -2595,7 +2848,8 @@
           "id": 169,
           "name": "Iowa Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -2604,7 +2858,8 @@
           "id": 362,
           "name": "Homestead Miami Speedway",
           "config": "Open Wheel Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -2613,7 +2868,8 @@
           "id": 225,
           "name": "Auto Club Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -2622,7 +2878,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -2654,7 +2911,8 @@
           "id": 225,
           "name": "Auto Club Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -2663,7 +2921,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -2672,7 +2931,8 @@
           "id": 418,
           "name": "Phoenix Raceway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -2680,7 +2940,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -2689,7 +2950,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -2698,7 +2960,8 @@
           "id": 198,
           "name": "Mobility Resort Motegi",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -2707,7 +2970,8 @@
           "id": 46,
           "name": "Barber Motorsports Park",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -2716,7 +2980,8 @@
           "id": 448,
           "name": "Indianapolis Motor Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -2725,7 +2990,8 @@
           "id": 192,
           "name": "Daytona International Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -2734,7 +3000,8 @@
           "id": 453,
           "name": "Indianapolis Motor Speedway",
           "config": "Open Wheel Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -2743,7 +3010,8 @@
           "id": 319,
           "name": "Detroit Grand Prix at Belle Isle",
           "config": "Belle Isle"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -2752,7 +3020,8 @@
           "id": 237,
           "name": "World Wide Technology Raceway (Gateway)",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -2784,7 +3053,8 @@
           "id": 449,
           "name": "Motorsport Arena Oschersleben",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -2793,7 +3063,8 @@
           "id": 9,
           "name": "Summit Point Raceway",
           "config": "Summit Point Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -2802,7 +3073,8 @@
           "id": 354,
           "name": "Lime Rock Park",
           "config": "Chicanes"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -2811,7 +3083,8 @@
           "id": 439,
           "name": "Winton Motor Raceway",
           "config": "National Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -2820,7 +3093,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -2828,7 +3102,8 @@
         "track": {
           "id": 489,
           "name": "Circuit de Lédenon"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -2837,7 +3112,8 @@
           "id": 350,
           "name": "Charlotte Motor Speedway",
           "config": "Roval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -2846,7 +3122,8 @@
           "id": 180,
           "name": "Oulton Park Circuit",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -2855,7 +3132,8 @@
           "id": 324,
           "name": "Tsukuba Circuit",
           "config": "2000 Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -2864,7 +3142,8 @@
           "id": 467,
           "name": "Virginia International Raceway",
           "config": "North Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -2873,7 +3152,8 @@
           "id": 515,
           "name": "Circuito de Navarra",
           "config": "Speed Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -2882,13 +3162,14 @@
           "id": 166,
           "name": "Okayama International Circuit",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
   "164": {
     "id": 164,
-    "name": "NASCAR Class C Maconi Series - Fixed",
+    "name": "NASCAR Class C Series - Fixed",
     "category": "oval",
     "laps": 40,
     "duration": null,
@@ -2916,7 +3197,8 @@
           "id": 20,
           "name": "Homestead Miami Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -2924,7 +3206,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -2932,7 +3215,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -2941,7 +3225,8 @@
           "id": 365,
           "name": "Bristol Motor Speedway",
           "config": "Single Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -2950,7 +3235,8 @@
           "id": 203,
           "name": "Rockingham Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -2958,7 +3244,8 @@
         "track": {
           "id": 162,
           "name": "Dover Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -2967,7 +3254,8 @@
           "id": 357,
           "name": "Texas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -2976,7 +3264,8 @@
           "id": 214,
           "name": "Kansas Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -2985,7 +3274,8 @@
           "id": 366,
           "name": "North Wilkesboro Speedway",
           "config": "1987"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -2994,7 +3284,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -3002,7 +3293,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -3010,7 +3302,8 @@
         "track": {
           "id": 276,
           "name": "Michigan International Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -3042,7 +3335,8 @@
           "id": 225,
           "name": "Auto Club Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -3051,7 +3345,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -3060,7 +3355,8 @@
           "id": 419,
           "name": "Phoenix Raceway",
           "config": "Oval w/open dogleg"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -3068,7 +3364,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -3077,7 +3374,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -3086,7 +3384,8 @@
           "id": 198,
           "name": "Mobility Resort Motegi",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -3095,7 +3394,8 @@
           "id": 46,
           "name": "Barber Motorsports Park",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -3104,7 +3404,8 @@
           "id": 448,
           "name": "Indianapolis Motor Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -3113,7 +3414,8 @@
           "id": 192,
           "name": "Daytona International Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -3122,7 +3424,8 @@
           "id": 453,
           "name": "Indianapolis Motor Speedway",
           "config": "Open Wheel Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -3131,7 +3434,8 @@
           "id": 319,
           "name": "Detroit Grand Prix at Belle Isle",
           "config": "Belle Isle"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -3140,7 +3444,8 @@
           "id": 237,
           "name": "World Wide Technology Raceway (Gateway)",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -3174,7 +3479,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -3182,7 +3488,8 @@
         "track": {
           "id": 162,
           "name": "Dover Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -3191,7 +3498,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -3200,7 +3508,8 @@
           "id": 103,
           "name": "Las Vegas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -3208,7 +3517,8 @@
         "track": {
           "id": 276,
           "name": "Michigan International Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -3216,7 +3526,8 @@
         "track": {
           "id": 201,
           "name": "Langley Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -3225,7 +3536,8 @@
           "id": 433,
           "name": "Watkins Glen International",
           "config": "Cup"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -3234,7 +3546,8 @@
           "id": 366,
           "name": "North Wilkesboro Speedway",
           "config": "1987"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -3242,7 +3555,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -3251,7 +3565,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -3260,7 +3575,8 @@
           "id": 101,
           "name": "Bristol Motor Speedway",
           "config": "Dual Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -3269,7 +3585,8 @@
           "id": 357,
           "name": "Texas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -3303,7 +3620,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -3311,7 +3629,8 @@
         "track": {
           "id": 201,
           "name": "Langley Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -3320,7 +3639,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -3328,7 +3648,8 @@
         "track": {
           "id": 256,
           "name": "Southern National Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -3336,7 +3657,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -3344,7 +3666,8 @@
         "track": {
           "id": 15,
           "name": "Concord Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -3352,7 +3675,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -3361,7 +3685,8 @@
           "id": 17,
           "name": "Lanier National Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -3370,7 +3695,8 @@
           "id": 161,
           "name": "Thompson Speedway Motorsports Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -3379,7 +3705,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -3387,7 +3714,8 @@
         "track": {
           "id": 201,
           "name": "Langley Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -3396,7 +3724,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -3430,7 +3759,8 @@
           "id": 493,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Asphalt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -3439,7 +3769,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -3448,7 +3779,8 @@
           "id": 374,
           "name": "Nashville Fairgrounds Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -3457,7 +3789,8 @@
           "id": 161,
           "name": "Thompson Speedway Motorsports Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -3465,7 +3798,8 @@
         "track": {
           "id": 414,
           "name": "Hickory Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -3473,7 +3807,8 @@
         "track": {
           "id": 248,
           "name": "Five Flags Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -3482,7 +3817,8 @@
           "id": 169,
           "name": "Iowa Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -3491,7 +3827,8 @@
           "id": 366,
           "name": "North Wilkesboro Speedway",
           "config": "1987"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -3499,7 +3836,8 @@
         "track": {
           "id": 201,
           "name": "Langley Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -3508,7 +3846,8 @@
           "id": 365,
           "name": "Bristol Motor Speedway",
           "config": "Single Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -3516,7 +3855,8 @@
         "track": {
           "id": 162,
           "name": "Dover Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -3524,7 +3864,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -3558,7 +3899,8 @@
           "id": 20,
           "name": "Homestead Miami Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -3566,7 +3908,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -3574,7 +3917,8 @@
         "track": {
           "id": 115,
           "name": "Darlington Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -3583,7 +3927,8 @@
           "id": 365,
           "name": "Bristol Motor Speedway",
           "config": "Single Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -3592,7 +3937,8 @@
           "id": 103,
           "name": "Las Vegas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -3600,7 +3946,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -3609,7 +3956,8 @@
           "id": 357,
           "name": "Texas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -3618,7 +3966,8 @@
           "id": 214,
           "name": "Kansas Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -3627,7 +3976,8 @@
           "id": 371,
           "name": "Kentucky Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -3636,7 +3986,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -3644,7 +3995,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -3652,7 +4004,8 @@
         "track": {
           "id": 276,
           "name": "Michigan International Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -3684,7 +4037,8 @@
           "id": 480,
           "name": "MotorLand Aragón",
           "config": "Outer"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -3693,7 +4047,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -3702,7 +4057,8 @@
           "id": 264,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke Long"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -3711,7 +4067,8 @@
           "id": 445,
           "name": "Fuji International Speedway",
           "config": "No Chicane"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -3719,7 +4076,8 @@
         "track": {
           "id": 532,
           "name": "Thruxton Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -3728,7 +4086,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -3737,7 +4096,8 @@
           "id": 432,
           "name": "Watkins Glen International",
           "config": "Classic"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -3746,7 +4106,8 @@
           "id": 46,
           "name": "Barber Motorsports Park",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -3755,7 +4116,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -3764,7 +4126,8 @@
           "id": 195,
           "name": "Mobility Resort Motegi",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -3773,7 +4136,8 @@
           "id": 242,
           "name": "Autodromo Nazionale Monza",
           "config": "GP without chicanes"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -3782,7 +4146,8 @@
           "id": 350,
           "name": "Charlotte Motor Speedway",
           "config": "Roval"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -3816,7 +4181,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -3825,7 +4191,8 @@
           "id": 447,
           "name": "Atlanta Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -3834,7 +4201,8 @@
           "id": 231,
           "name": "Circuit of the Americas",
           "config": "West"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -3843,7 +4211,8 @@
           "id": 419,
           "name": "Phoenix Raceway",
           "config": "Oval w/open dogleg"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -3852,7 +4221,8 @@
           "id": 103,
           "name": "Las Vegas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -3861,7 +4231,8 @@
           "id": 20,
           "name": "Homestead Miami Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -3869,7 +4240,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -3877,7 +4249,8 @@
         "track": {
           "id": 115,
           "name": "Darlington Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -3886,7 +4259,8 @@
           "id": 365,
           "name": "Bristol Motor Speedway",
           "config": "Single Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -3894,7 +4268,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -3903,7 +4278,8 @@
           "id": 357,
           "name": "Texas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -3912,7 +4288,8 @@
           "id": 214,
           "name": "Kansas Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -3921,7 +4298,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 13,
@@ -3929,7 +4307,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 14,
@@ -3937,7 +4316,8 @@
         "track": {
           "id": 276,
           "name": "Michigan International Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 15,
@@ -3946,7 +4326,8 @@
           "id": 381,
           "name": "Daytona International Speedway",
           "config": "NASCAR Road"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 16,
@@ -3954,7 +4335,8 @@
         "track": {
           "id": 277,
           "name": "Pocono Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 17,
@@ -3963,7 +4345,8 @@
           "id": 447,
           "name": "Atlanta Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 18,
@@ -3972,7 +4355,8 @@
           "id": 483,
           "name": "Chicago Street Course",
           "config": "2023 Cup"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 19,
@@ -3981,7 +4365,8 @@
           "id": 48,
           "name": "Sonoma Raceway",
           "config": "NASCAR Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 20,
@@ -3989,7 +4374,8 @@
         "track": {
           "id": 162,
           "name": "Dover Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 21,
@@ -3998,7 +4384,8 @@
           "id": 522,
           "name": "Indianapolis Motor Speedway",
           "config": "NASCAR Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 22,
@@ -4007,7 +4394,8 @@
           "id": 169,
           "name": "Iowa Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 23,
@@ -4016,7 +4404,8 @@
           "id": 433,
           "name": "Watkins Glen International",
           "config": "Cup"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 24,
@@ -4024,7 +4413,8 @@
         "track": {
           "id": 31,
           "name": "Richmond Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 25,
@@ -4033,7 +4423,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 26,
@@ -4041,7 +4432,8 @@
         "track": {
           "id": 115,
           "name": "Darlington Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 27,
@@ -4050,7 +4442,8 @@
           "id": 237,
           "name": "World Wide Technology Raceway (Gateway)",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 28,
@@ -4059,7 +4452,8 @@
           "id": 365,
           "name": "Bristol Motor Speedway",
           "config": "Single Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 29,
@@ -4068,7 +4462,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 30,
@@ -4077,7 +4472,8 @@
           "id": 214,
           "name": "Kansas Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 31,
@@ -4086,7 +4482,8 @@
           "id": 350,
           "name": "Charlotte Motor Speedway",
           "config": "Roval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 32,
@@ -4095,7 +4492,8 @@
           "id": 103,
           "name": "Las Vegas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 33,
@@ -4103,7 +4501,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 34,
@@ -4111,7 +4510,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 35,
@@ -4120,7 +4520,8 @@
           "id": 419,
           "name": "Phoenix Raceway",
           "config": "Oval w/open dogleg"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -4153,7 +4554,8 @@
           "id": 9,
           "name": "Summit Point Raceway",
           "config": "Summit Point Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -4162,7 +4564,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -4171,7 +4574,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -4180,7 +4584,8 @@
           "id": 202,
           "name": "Oran Park Raceway",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -4189,7 +4594,8 @@
           "id": 527,
           "name": "Cadwell Park Circuit",
           "config": "Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -4198,7 +4604,8 @@
           "id": 192,
           "name": "Daytona International Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -4207,7 +4614,8 @@
           "id": 403,
           "name": "Red Bull Ring",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -4216,7 +4624,8 @@
           "id": 435,
           "name": "Watkins Glen International",
           "config": "Classic Boot"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -4225,7 +4634,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -4233,7 +4643,8 @@
         "track": {
           "id": 152,
           "name": "Phillip Island Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -4242,7 +4653,8 @@
           "id": 166,
           "name": "Okayama International Circuit",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -4251,7 +4663,8 @@
           "id": 18,
           "name": "Road America",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -4282,7 +4695,8 @@
         "track": {
           "id": 248,
           "name": "Five Flags Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -4291,7 +4705,8 @@
           "id": 161,
           "name": "Thompson Speedway Motorsports Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -4299,7 +4714,8 @@
         "track": {
           "id": 271,
           "name": "The Bullring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -4307,7 +4723,8 @@
         "track": {
           "id": 190,
           "name": "New Smyrna Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -4316,7 +4733,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -4324,7 +4742,8 @@
         "track": {
           "id": 256,
           "name": "Southern National Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -4332,7 +4751,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -4341,7 +4761,8 @@
           "id": 374,
           "name": "Nashville Fairgrounds Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -4350,7 +4771,8 @@
           "id": 366,
           "name": "North Wilkesboro Speedway",
           "config": "1987"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -4358,7 +4780,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -4366,7 +4789,8 @@
         "track": {
           "id": 414,
           "name": "Hickory Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -4375,7 +4799,8 @@
           "id": 493,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Asphalt Track"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -4416,7 +4841,8 @@
           "id": 403,
           "name": "Red Bull Ring",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -4425,7 +4851,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 26
       },
       {
         "weekNum": 2,
@@ -4434,7 +4861,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -4443,7 +4871,8 @@
           "id": 498,
           "name": "Autodromo Internazionale del Mugello",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -4452,7 +4881,8 @@
           "id": 18,
           "name": "Road America",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 39
       },
       {
         "weekNum": 5,
@@ -4461,7 +4891,8 @@
           "id": 229,
           "name": "Circuit of the Americas",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -4470,7 +4901,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -4479,7 +4911,8 @@
           "id": 268,
           "name": "Circuit des 24 Heures du Mans",
           "config": "24 Heures du Mans"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -4488,7 +4921,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0.7
       },
       {
         "weekNum": 9,
@@ -4497,7 +4931,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -4506,7 +4941,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 11
       },
       {
         "weekNum": 11,
@@ -4515,7 +4951,8 @@
           "id": 252,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke 24h"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -4549,7 +4986,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -4558,7 +4996,8 @@
           "id": 447,
           "name": "Atlanta Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -4567,7 +5006,8 @@
           "id": 231,
           "name": "Circuit of the Americas",
           "config": "West"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -4576,7 +5016,8 @@
           "id": 419,
           "name": "Phoenix Raceway",
           "config": "Oval w/open dogleg"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -4585,7 +5026,8 @@
           "id": 103,
           "name": "Las Vegas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -4594,7 +5036,8 @@
           "id": 20,
           "name": "Homestead Miami Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -4602,7 +5045,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -4610,7 +5054,8 @@
         "track": {
           "id": 115,
           "name": "Darlington Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -4619,7 +5064,8 @@
           "id": 365,
           "name": "Bristol Motor Speedway",
           "config": "Single Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -4627,7 +5073,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -4636,7 +5083,8 @@
           "id": 357,
           "name": "Texas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -4645,7 +5093,8 @@
           "id": 214,
           "name": "Kansas Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -4654,7 +5103,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 13,
@@ -4662,7 +5112,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 14,
@@ -4670,7 +5121,8 @@
         "track": {
           "id": 276,
           "name": "Michigan International Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 15,
@@ -4679,7 +5131,8 @@
           "id": 381,
           "name": "Daytona International Speedway",
           "config": "NASCAR Road"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 16,
@@ -4687,7 +5140,8 @@
         "track": {
           "id": 277,
           "name": "Pocono Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 17,
@@ -4696,7 +5150,8 @@
           "id": 447,
           "name": "Atlanta Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 18,
@@ -4705,7 +5160,8 @@
           "id": 483,
           "name": "Chicago Street Course",
           "config": "2023 Cup"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 19,
@@ -4714,7 +5170,8 @@
           "id": 48,
           "name": "Sonoma Raceway",
           "config": "NASCAR Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 20,
@@ -4722,7 +5179,8 @@
         "track": {
           "id": 162,
           "name": "Dover Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 21,
@@ -4731,7 +5189,8 @@
           "id": 522,
           "name": "Indianapolis Motor Speedway",
           "config": "NASCAR Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 22,
@@ -4740,7 +5199,8 @@
           "id": 169,
           "name": "Iowa Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 23,
@@ -4749,7 +5209,8 @@
           "id": 433,
           "name": "Watkins Glen International",
           "config": "Cup"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 24,
@@ -4757,7 +5218,8 @@
         "track": {
           "id": 31,
           "name": "Richmond Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 25,
@@ -4766,7 +5228,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 26,
@@ -4774,7 +5237,8 @@
         "track": {
           "id": 115,
           "name": "Darlington Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 27,
@@ -4783,7 +5247,8 @@
           "id": 237,
           "name": "World Wide Technology Raceway (Gateway)",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 28,
@@ -4792,7 +5257,8 @@
           "id": 365,
           "name": "Bristol Motor Speedway",
           "config": "Single Pit Roads"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 29,
@@ -4801,7 +5267,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 30,
@@ -4810,7 +5277,8 @@
           "id": 214,
           "name": "Kansas Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 31,
@@ -4819,7 +5287,8 @@
           "id": 350,
           "name": "Charlotte Motor Speedway",
           "config": "Roval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 32,
@@ -4828,7 +5297,8 @@
           "id": 103,
           "name": "Las Vegas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 33,
@@ -4836,7 +5306,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 34,
@@ -4844,7 +5315,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 35,
@@ -4853,7 +5325,8 @@
           "id": 419,
           "name": "Phoenix Raceway",
           "config": "Oval w/open dogleg"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -4884,7 +5357,8 @@
         "track": {
           "id": 219,
           "name": "Mount Panorama Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -4893,7 +5367,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 12
       },
       {
         "weekNum": 2,
@@ -4902,7 +5377,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -4911,7 +5387,8 @@
           "id": 498,
           "name": "Autodromo Internazionale del Mugello",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -4920,7 +5397,8 @@
           "id": 46,
           "name": "Barber Motorsports Park",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -4929,7 +5407,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -4938,7 +5417,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -4947,7 +5427,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -4956,7 +5437,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -4965,7 +5447,8 @@
           "id": 319,
           "name": "Detroit Grand Prix at Belle Isle",
           "config": "Belle Isle"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -4974,7 +5457,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 31
       },
       {
         "weekNum": 11,
@@ -4982,7 +5466,8 @@
         "track": {
           "id": 218,
           "name": "Circuit Gilles Villeneuve"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -5023,7 +5508,8 @@
           "id": 403,
           "name": "Red Bull Ring",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 31
       },
       {
         "weekNum": 1,
@@ -5032,7 +5518,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -5041,7 +5528,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -5050,7 +5538,8 @@
           "id": 498,
           "name": "Autodromo Internazionale del Mugello",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 30
       },
       {
         "weekNum": 4,
@@ -5059,7 +5548,8 @@
           "id": 18,
           "name": "Road America",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -5068,7 +5558,8 @@
           "id": 229,
           "name": "Circuit of the Americas",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 5.7
       },
       {
         "weekNum": 6,
@@ -5077,7 +5568,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -5086,7 +5578,8 @@
           "id": 268,
           "name": "Circuit des 24 Heures du Mans",
           "config": "24 Heures du Mans"
-        }
+        },
+        "rainChance": 37
       },
       {
         "weekNum": 8,
@@ -5095,7 +5588,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -5104,7 +5598,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 48
       },
       {
         "weekNum": 10,
@@ -5113,7 +5608,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -5122,7 +5618,8 @@
           "id": 252,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke 24h"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -5154,7 +5651,8 @@
           "id": 27,
           "name": "Daytona International Speedway",
           "config": "Oval - 2008"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -5163,7 +5661,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -5172,7 +5671,8 @@
           "id": 104,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -5181,7 +5681,8 @@
           "id": 27,
           "name": "Daytona International Speedway",
           "config": "Oval - 2008"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -5190,7 +5691,8 @@
           "id": 136,
           "name": "[Legacy] Pocono Raceway - 2009",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -5199,7 +5701,8 @@
           "id": 104,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -5208,7 +5711,8 @@
           "id": 27,
           "name": "Daytona International Speedway",
           "config": "Oval - 2008"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -5217,7 +5721,8 @@
           "id": 40,
           "name": "[Legacy] Charlotte Motor Speedway - 2008",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -5226,7 +5731,8 @@
           "id": 104,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -5235,7 +5741,8 @@
           "id": 136,
           "name": "[Legacy] Pocono Raceway - 2009",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -5244,7 +5751,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -5253,7 +5761,8 @@
           "id": 104,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -5262,7 +5771,8 @@
           "id": 27,
           "name": "Daytona International Speedway",
           "config": "Oval - 2008"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -5294,7 +5804,8 @@
           "id": 498,
           "name": "Autodromo Internazionale del Mugello",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -5303,7 +5814,8 @@
           "id": 501,
           "name": "Misano World Circuit Marco Simoncelli",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -5312,7 +5824,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -5321,7 +5834,8 @@
           "id": 250,
           "name": "Nürburgring Grand-Prix-Strecke",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -5330,7 +5844,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -5339,7 +5854,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -5348,7 +5864,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -5357,7 +5874,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -5366,7 +5884,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -5374,7 +5893,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -5383,7 +5903,8 @@
           "id": 349,
           "name": "Circuit de Barcelona Catalunya",
           "config": "Historic"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -5392,54 +5913,8 @@
           "id": 463,
           "name": "Circuit de Nevers Magny-Cours",
           "config": "Grand Prix"
-        }
-      }
-    ]
-  },
-  "271": {
-    "id": 271,
-    "name": "12 Hours of Sebring",
-    "category": "sports_car",
-    "laps": null,
-    "duration": 720,
-    "switching": false,
-    "official": true,
-    "fixed": false,
-    "multiclass": true,
-    "cars": [
-      128,
-      176,
-      194,
-      132,
-      133,
-      184,
-      169,
-      185,
-      156,
-      188,
-      173,
-      196,
-      168,
-      170,
-      174,
-      159
-    ],
-    "license": {
-      "id": 3,
-      "name": "Class C",
-      "letter": "C",
-      "color": "feec04"
-    },
-    "logo": "seriesid_271.png",
-    "weeks": [
-      {
-        "weekNum": 0,
-        "date": "2025-03-21",
-        "track": {
-          "id": 95,
-          "name": "Sebring International Raceway",
-          "config": "International"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -5486,7 +5961,8 @@
           "id": 262,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke VLN"
-        }
+        },
+        "rainChance": 46
       },
       {
         "weekNum": 1,
@@ -5495,7 +5971,8 @@
           "id": 262,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke VLN"
-        }
+        },
+        "rainChance": 42
       },
       {
         "weekNum": 2,
@@ -5504,7 +5981,8 @@
           "id": 262,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke VLN"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -5513,7 +5991,8 @@
           "id": 262,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke VLN"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -5522,7 +6001,8 @@
           "id": 262,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke VLN"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -5531,7 +6011,8 @@
           "id": 262,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke VLN"
-        }
+        },
+        "rainChance": 32
       },
       {
         "weekNum": 6,
@@ -5540,7 +6021,8 @@
           "id": 262,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke VLN"
-        }
+        },
+        "rainChance": 15
       },
       {
         "weekNum": 7,
@@ -5549,7 +6031,8 @@
           "id": 262,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke VLN"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -5558,7 +6041,8 @@
           "id": 262,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke VLN"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -5591,7 +6075,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -5600,7 +6085,8 @@
           "id": 481,
           "name": "Willow Springs International Raceway",
           "config": "Big Willow"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -5608,7 +6094,8 @@
         "track": {
           "id": 532,
           "name": "Thruxton Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -5616,7 +6103,8 @@
         "track": {
           "id": 219,
           "name": "Mount Panorama Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -5624,7 +6112,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -5633,7 +6122,8 @@
           "id": 18,
           "name": "Road America",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -5642,7 +6132,8 @@
           "id": 448,
           "name": "Indianapolis Motor Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -5651,7 +6142,8 @@
           "id": 9,
           "name": "Summit Point Raceway",
           "config": "Summit Point Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -5660,7 +6152,8 @@
           "id": 524,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Classic Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -5668,7 +6161,8 @@
         "track": {
           "id": 152,
           "name": "Phillip Island Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -5677,7 +6171,8 @@
           "id": 485,
           "name": "Circuit Zandvoort",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -5686,7 +6181,8 @@
           "id": 269,
           "name": "Circuit des 24 Heures du Mans",
           "config": "Historic"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -5717,7 +6213,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -5725,7 +6222,8 @@
         "track": {
           "id": 446,
           "name": "Port Royal Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -5733,7 +6231,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -5741,7 +6240,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -5750,7 +6250,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -5758,7 +6259,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -5766,7 +6268,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -5774,7 +6277,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -5783,7 +6287,8 @@
           "id": 320,
           "name": "Kokomo Speedway",
           "config": "Tires in"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -5791,7 +6296,8 @@
         "track": {
           "id": 452,
           "name": "Lucas Oil Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -5799,7 +6305,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -5807,7 +6314,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -5838,7 +6346,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -5846,7 +6355,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -5854,7 +6364,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -5862,7 +6373,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -5870,7 +6382,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -5879,7 +6392,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -5887,7 +6401,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -5896,7 +6411,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -5904,7 +6420,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -5912,7 +6429,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -5920,7 +6438,8 @@
         "track": {
           "id": 274,
           "name": "Williams Grove Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -5928,7 +6447,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -5960,7 +6480,8 @@
           "id": 341,
           "name": "Silverstone Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -5969,7 +6490,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 27
       },
       {
         "weekNum": 2,
@@ -5978,7 +6500,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -5987,7 +6510,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -5996,7 +6520,8 @@
           "id": 184,
           "name": "Oulton Park Circuit",
           "config": "Intl w/out Brittens"
-        }
+        },
+        "rainChance": 84
       },
       {
         "weekNum": 5,
@@ -6005,7 +6530,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -6014,7 +6540,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -6023,7 +6550,8 @@
           "id": 192,
           "name": "Daytona International Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -6032,7 +6560,8 @@
           "id": 403,
           "name": "Red Bull Ring",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 26
       },
       {
         "weekNum": 9,
@@ -6041,7 +6570,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -6050,7 +6580,8 @@
           "id": 432,
           "name": "Watkins Glen International",
           "config": "Classic"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -6059,7 +6590,8 @@
           "id": 252,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke 24h"
-        }
+        },
+        "rainChance": 62
       }
     ]
   },
@@ -6090,7 +6622,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -6098,7 +6631,8 @@
         "track": {
           "id": 274,
           "name": "Williams Grove Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -6106,7 +6640,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -6114,7 +6649,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -6123,7 +6659,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -6131,7 +6668,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -6140,7 +6678,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -6148,7 +6687,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -6156,7 +6696,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -6164,7 +6705,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -6172,7 +6714,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -6180,7 +6723,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -6211,7 +6755,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -6219,7 +6764,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -6227,7 +6773,8 @@
         "track": {
           "id": 452,
           "name": "Lucas Oil Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -6236,7 +6783,8 @@
           "id": 320,
           "name": "Kokomo Speedway",
           "config": "Tires in"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -6244,7 +6792,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -6252,7 +6801,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -6260,7 +6810,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -6269,7 +6820,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -6277,7 +6829,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -6285,7 +6838,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -6293,7 +6847,8 @@
         "track": {
           "id": 446,
           "name": "Port Royal Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -6301,7 +6856,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -6332,7 +6888,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -6341,7 +6898,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -6349,7 +6907,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -6357,7 +6916,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -6365,7 +6925,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -6373,7 +6934,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -6381,7 +6943,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -6389,7 +6952,8 @@
         "track": {
           "id": 274,
           "name": "Williams Grove Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -6398,7 +6962,8 @@
           "id": 320,
           "name": "Kokomo Speedway",
           "config": "Tires in"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -6406,7 +6971,8 @@
         "track": {
           "id": 446,
           "name": "Port Royal Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -6415,7 +6981,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -6423,7 +6990,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -6454,7 +7022,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -6462,7 +7031,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -6470,7 +7040,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -6478,7 +7049,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -6487,7 +7059,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -6495,7 +7068,8 @@
         "track": {
           "id": 446,
           "name": "Port Royal Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -6503,7 +7077,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -6511,7 +7086,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -6520,7 +7096,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -6528,7 +7105,8 @@
         "track": {
           "id": 452,
           "name": "Lucas Oil Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -6536,7 +7114,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -6544,7 +7123,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -6576,7 +7156,8 @@
           "id": 514,
           "name": "Kokomo Speedway",
           "config": "Tires out"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -6584,7 +7165,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -6592,7 +7174,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -6600,7 +7183,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -6609,7 +7193,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -6617,7 +7202,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -6625,7 +7211,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -6633,7 +7220,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -6641,7 +7229,8 @@
         "track": {
           "id": 462,
           "name": "Lincoln Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -6649,7 +7238,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -6657,7 +7247,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -6666,7 +7257,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -6698,7 +7290,8 @@
           "id": 514,
           "name": "Kokomo Speedway",
           "config": "Tires out"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -6706,7 +7299,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -6714,7 +7308,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -6722,7 +7317,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -6731,7 +7327,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -6739,7 +7336,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -6747,7 +7345,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -6755,7 +7354,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -6763,7 +7363,8 @@
         "track": {
           "id": 462,
           "name": "Lincoln Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -6771,7 +7372,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -6779,7 +7381,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -6788,7 +7391,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -6820,7 +7424,8 @@
           "id": 514,
           "name": "Kokomo Speedway",
           "config": "Tires out"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -6828,7 +7433,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -6836,7 +7442,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -6844,7 +7451,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -6853,7 +7461,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -6861,7 +7470,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -6869,7 +7479,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -6877,7 +7488,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -6885,7 +7497,8 @@
         "track": {
           "id": 462,
           "name": "Lincoln Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -6893,7 +7506,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -6901,7 +7515,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -6910,7 +7525,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -6942,7 +7558,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -6950,7 +7567,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -6959,7 +7577,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -6967,7 +7586,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -6975,7 +7595,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -6983,7 +7604,8 @@
         "track": {
           "id": 513,
           "name": "Millbridge Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -6992,7 +7614,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -7000,7 +7623,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -7009,7 +7633,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -7018,7 +7643,8 @@
           "id": 497,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Mini Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -7026,7 +7652,8 @@
         "track": {
           "id": 462,
           "name": "Lincoln Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -7034,7 +7661,8 @@
         "track": {
           "id": 331,
           "name": "Chili Bowl"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -7068,7 +7696,8 @@
           "id": 290,
           "name": "Brands Hatch Circuit",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -7077,7 +7706,8 @@
           "id": 358,
           "name": "Lånkebanen (Hell RX)",
           "config": "Hell Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -7086,7 +7716,8 @@
           "id": 306,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -7095,7 +7726,8 @@
           "id": 312,
           "name": "Sonoma Raceway",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -7104,7 +7736,8 @@
           "id": 304,
           "name": "Lucas Oil Indianapolis Raceway Park",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -7113,7 +7746,8 @@
           "id": 385,
           "name": "Charlotte Motor Speedway",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -7122,7 +7756,8 @@
           "id": 295,
           "name": "Iowa Speedway",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -7131,7 +7766,8 @@
           "id": 323,
           "name": "Atlanta Motor Speedway",
           "config": "Rallycross Long"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -7140,7 +7776,8 @@
           "id": 296,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Rallycross Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -7149,7 +7786,8 @@
           "id": 427,
           "name": "Knockhill Racing Circuit",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -7158,7 +7796,8 @@
           "id": 360,
           "name": "Lånkebanen (Hell RX)",
           "config": "Rallycross Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -7167,7 +7806,8 @@
           "id": 293,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Rallycross Long"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -7199,7 +7839,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -7207,7 +7848,8 @@
         "track": {
           "id": 513,
           "name": "Millbridge Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -7215,7 +7857,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -7223,7 +7866,8 @@
         "track": {
           "id": 331,
           "name": "Chili Bowl"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -7231,7 +7875,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -7240,7 +7885,8 @@
           "id": 514,
           "name": "Kokomo Speedway",
           "config": "Tires out"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -7248,7 +7894,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -7256,7 +7903,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -7264,7 +7912,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -7272,7 +7921,8 @@
         "track": {
           "id": 452,
           "name": "Lucas Oil Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -7281,7 +7931,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -7289,13 +7940,14 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
   "331": {
     "id": 331,
-    "name": "Global Endurance Tour by CONSPIT",
+    "name": "Global Endurance Tour",
     "category": "sports_car",
     "laps": null,
     "duration": 360,
@@ -7336,7 +7988,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 35
       },
       {
         "weekNum": 1,
@@ -7344,7 +7997,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -7353,7 +8007,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 38
       },
       {
         "weekNum": 3,
@@ -7362,7 +8017,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -7371,7 +8027,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 34
       },
       {
         "weekNum": 5,
@@ -7380,7 +8037,8 @@
           "id": 268,
           "name": "Circuit des 24 Heures du Mans",
           "config": "24 Heures du Mans"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -7412,7 +8070,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -7421,7 +8080,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -7430,7 +8090,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -7439,7 +8100,8 @@
           "id": 166,
           "name": "Okayama International Circuit",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -7448,7 +8110,8 @@
           "id": 247,
           "name": "Autodromo Nazionale Monza",
           "config": "Combined"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -7457,7 +8120,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -7466,7 +8130,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -7475,7 +8140,8 @@
           "id": 180,
           "name": "Oulton Park Circuit",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -7484,7 +8150,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -7492,7 +8159,8 @@
         "track": {
           "id": 532,
           "name": "Thruxton Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -7500,7 +8168,8 @@
         "track": {
           "id": 451,
           "name": "Rudskogen Motorsenter"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -7509,7 +8178,8 @@
           "id": 501,
           "name": "Misano World Circuit Marco Simoncelli",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -7540,7 +8210,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -7548,7 +8219,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -7556,7 +8228,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -7564,7 +8237,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -7573,7 +8247,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -7581,7 +8256,8 @@
         "track": {
           "id": 446,
           "name": "Port Royal Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -7589,7 +8265,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -7597,7 +8274,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -7606,7 +8284,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -7614,7 +8293,8 @@
         "track": {
           "id": 452,
           "name": "Lucas Oil Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -7622,7 +8302,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -7630,7 +8311,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -7662,7 +8344,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -7671,7 +8354,8 @@
           "id": 225,
           "name": "Auto Club Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -7679,7 +8363,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -7688,7 +8373,8 @@
           "id": 46,
           "name": "Barber Motorsports Park",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -7697,7 +8383,8 @@
           "id": 448,
           "name": "Indianapolis Motor Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -7706,7 +8393,8 @@
           "id": 453,
           "name": "Indianapolis Motor Speedway",
           "config": "Open Wheel Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -7715,7 +8403,8 @@
           "id": 319,
           "name": "Detroit Grand Prix at Belle Isle",
           "config": "Belle Isle"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -7724,7 +8413,8 @@
           "id": 237,
           "name": "World Wide Technology Raceway (Gateway)",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -7733,7 +8423,8 @@
           "id": 18,
           "name": "Road America",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -7742,7 +8433,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -7751,7 +8443,8 @@
           "id": 169,
           "name": "Iowa Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -7759,7 +8452,8 @@
         "track": {
           "id": 218,
           "name": "Circuit Gilles Villeneuve"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -7768,7 +8462,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 13,
@@ -7777,7 +8472,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 14,
@@ -7785,7 +8481,8 @@
         "track": {
           "id": 94,
           "name": "The Milwaukee Mile"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 15,
@@ -7793,7 +8490,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -7825,7 +8523,8 @@
           "id": 383,
           "name": "Crandon International Raceway",
           "config": "Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -7833,7 +8532,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -7841,7 +8541,8 @@
         "track": {
           "id": 396,
           "name": "Bark River International Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -7850,7 +8551,8 @@
           "id": 382,
           "name": "Crandon International Raceway",
           "config": "Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -7858,7 +8560,8 @@
         "track": {
           "id": 334,
           "name": "Firebird Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -7866,7 +8569,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -7874,7 +8578,8 @@
         "track": {
           "id": 396,
           "name": "Bark River International Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -7883,7 +8588,8 @@
           "id": 383,
           "name": "Crandon International Raceway",
           "config": "Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -7891,7 +8597,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -7899,7 +8606,8 @@
         "track": {
           "id": 334,
           "name": "Firebird Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -7907,7 +8615,8 @@
         "track": {
           "id": 396,
           "name": "Bark River International Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -7916,7 +8625,8 @@
           "id": 382,
           "name": "Crandon International Raceway",
           "config": "Full"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -7949,7 +8659,8 @@
           "id": 483,
           "name": "Chicago Street Course",
           "config": "2023 Cup"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -7958,7 +8669,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 12
       },
       {
         "weekNum": 2,
@@ -7966,7 +8678,8 @@
         "track": {
           "id": 219,
           "name": "Mount Panorama Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -7975,7 +8688,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 27
       },
       {
         "weekNum": 4,
@@ -7984,7 +8698,8 @@
           "id": 233,
           "name": "Donington Park Racing Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -7993,7 +8708,8 @@
           "id": 46,
           "name": "Barber Motorsports Park",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -8002,7 +8718,8 @@
           "id": 439,
           "name": "Winton Motor Raceway",
           "config": "National Circuit"
-        }
+        },
+        "rainChance": 35
       },
       {
         "weekNum": 7,
@@ -8010,7 +8727,8 @@
         "track": {
           "id": 144,
           "name": "Canadian Tire Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -8019,7 +8737,8 @@
           "id": 192,
           "name": "Daytona International Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -8028,7 +8747,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 40
       },
       {
         "weekNum": 10,
@@ -8037,7 +8757,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -8046,7 +8767,8 @@
           "id": 48,
           "name": "Sonoma Raceway",
           "config": "NASCAR Short"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -8079,7 +8801,8 @@
           "id": 483,
           "name": "Chicago Street Course",
           "config": "2023 Cup"
-        }
+        },
+        "rainChance": 11
       },
       {
         "weekNum": 1,
@@ -8088,7 +8811,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -8096,7 +8820,8 @@
         "track": {
           "id": 219,
           "name": "Mount Panorama Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -8105,7 +8830,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -8114,7 +8840,8 @@
           "id": 233,
           "name": "Donington Park Racing Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 28
       },
       {
         "weekNum": 5,
@@ -8123,7 +8850,8 @@
           "id": 46,
           "name": "Barber Motorsports Park",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -8132,7 +8860,8 @@
           "id": 439,
           "name": "Winton Motor Raceway",
           "config": "National Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -8140,7 +8869,8 @@
         "track": {
           "id": 144,
           "name": "Canadian Tire Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -8149,7 +8879,8 @@
           "id": 192,
           "name": "Daytona International Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 21
       },
       {
         "weekNum": 9,
@@ -8158,7 +8889,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -8167,7 +8899,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 28
       },
       {
         "weekNum": 11,
@@ -8176,7 +8909,8 @@
           "id": 48,
           "name": "Sonoma Raceway",
           "config": "NASCAR Short"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -8211,7 +8945,8 @@
           "id": 203,
           "name": "Rockingham Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -8220,7 +8955,8 @@
           "id": 27,
           "name": "Daytona International Speedway",
           "config": "Oval - 2008"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -8229,7 +8965,8 @@
           "id": 121,
           "name": "[Legacy] Texas Motor Speedway - 2009",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -8238,7 +8975,8 @@
           "id": 169,
           "name": "Iowa Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -8247,7 +8985,8 @@
           "id": 225,
           "name": "Auto Club Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -8256,7 +8995,8 @@
           "id": 53,
           "name": "Atlanta Motor Speedway",
           "config": "Oval - 2008"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -8265,7 +9005,8 @@
           "id": 136,
           "name": "[Legacy] Pocono Raceway - 2009",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -8273,7 +9014,8 @@
         "track": {
           "id": 31,
           "name": "Richmond Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -8281,7 +9023,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -8289,7 +9032,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -8298,7 +9042,8 @@
           "id": 522,
           "name": "Indianapolis Motor Speedway",
           "config": "NASCAR Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -8306,7 +9051,8 @@
         "track": {
           "id": 123,
           "name": "Chicagoland Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -8338,7 +9084,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -8347,7 +9094,8 @@
           "id": 352,
           "name": "Lime Rock Park",
           "config": "Classic"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -8356,7 +9104,8 @@
           "id": 185,
           "name": "Oulton Park Circuit",
           "config": "Intl w/no Chicanes"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -8364,7 +9113,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -8373,7 +9123,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -8382,7 +9133,8 @@
           "id": 255,
           "name": "Nürburgring Grand-Prix-Strecke",
           "config": "BES/WEC"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -8391,7 +9143,8 @@
           "id": 9,
           "name": "Summit Point Raceway",
           "config": "Summit Point Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -8400,7 +9153,8 @@
           "id": 448,
           "name": "Indianapolis Motor Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -8409,7 +9163,8 @@
           "id": 232,
           "name": "Lucas Oil Indianapolis Raceway Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -8418,7 +9173,8 @@
           "id": 129,
           "name": "New Hampshire Motor Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -8426,7 +9182,8 @@
         "track": {
           "id": 532,
           "name": "Thruxton Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -8435,7 +9192,8 @@
           "id": 474,
           "name": "Circuito de Jerez - Ángel Nieto",
           "config": "Moto"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -8466,7 +9224,8 @@
         "track": {
           "id": 248,
           "name": "Five Flags Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -8475,7 +9234,8 @@
           "id": 161,
           "name": "Thompson Speedway Motorsports Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -8483,7 +9243,8 @@
         "track": {
           "id": 271,
           "name": "The Bullring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -8491,7 +9252,8 @@
         "track": {
           "id": 190,
           "name": "New Smyrna Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -8500,7 +9262,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -8508,7 +9271,8 @@
         "track": {
           "id": 256,
           "name": "Southern National Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -8516,7 +9280,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -8525,7 +9290,8 @@
           "id": 374,
           "name": "Nashville Fairgrounds Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -8534,7 +9300,8 @@
           "id": 366,
           "name": "North Wilkesboro Speedway",
           "config": "1987"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -8542,7 +9309,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -8550,7 +9318,8 @@
         "track": {
           "id": 414,
           "name": "Hickory Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -8559,7 +9328,8 @@
           "id": 493,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Asphalt Track"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -8591,7 +9361,8 @@
           "id": 374,
           "name": "Nashville Fairgrounds Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -8599,7 +9370,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -8608,7 +9380,8 @@
           "id": 161,
           "name": "Thompson Speedway Motorsports Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -8617,7 +9390,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -8625,7 +9399,8 @@
         "track": {
           "id": 414,
           "name": "Hickory Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -8633,7 +9408,8 @@
         "track": {
           "id": 271,
           "name": "The Bullring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -8642,7 +9418,8 @@
           "id": 11,
           "name": "Stafford Motor Speedway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -8650,7 +9427,8 @@
         "track": {
           "id": 201,
           "name": "Langley Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -8659,7 +9437,8 @@
           "id": 518,
           "name": "Oswego Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -8668,7 +9447,8 @@
           "id": 366,
           "name": "North Wilkesboro Speedway",
           "config": "1987"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -8676,7 +9456,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -8685,7 +9466,8 @@
           "id": 493,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Asphalt Track"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -8732,7 +9514,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -8741,7 +9524,8 @@
           "id": 444,
           "name": "Fuji International Speedway",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 23
       },
       {
         "weekNum": 2,
@@ -8750,7 +9534,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -8759,7 +9544,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 73
       },
       {
         "weekNum": 4,
@@ -8768,7 +9554,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -8777,7 +9564,8 @@
           "id": 319,
           "name": "Detroit Grand Prix at Belle Isle",
           "config": "Belle Isle"
-        }
+        },
+        "rainChance": 0.7
       }
     ]
   },
@@ -8808,7 +9596,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -8816,7 +9605,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -8824,7 +9614,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -8833,7 +9624,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -8841,7 +9633,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -8849,7 +9642,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -8857,7 +9651,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -8865,7 +9660,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -8874,7 +9670,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -8882,7 +9679,8 @@
         "track": {
           "id": 373,
           "name": "Weedsport Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -8891,7 +9689,8 @@
           "id": 442,
           "name": "Bristol Motor Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -8900,7 +9699,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -8932,7 +9732,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -8941,7 +9742,8 @@
           "id": 515,
           "name": "Circuito de Navarra",
           "config": "Speed Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -8950,7 +9752,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -8959,7 +9762,8 @@
           "id": 103,
           "name": "Las Vegas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -8968,7 +9772,8 @@
           "id": 195,
           "name": "Mobility Resort Motegi",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -8976,7 +9781,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -8985,7 +9791,8 @@
           "id": 448,
           "name": "Indianapolis Motor Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -8994,7 +9801,8 @@
           "id": 453,
           "name": "Indianapolis Motor Speedway",
           "config": "Open Wheel Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -9003,7 +9811,8 @@
           "id": 524,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Classic Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -9012,7 +9821,8 @@
           "id": 341,
           "name": "Silverstone Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -9020,7 +9830,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -9029,7 +9840,8 @@
           "id": 297,
           "name": "Snetterton Circuit",
           "config": "300"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -9064,7 +9876,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -9073,7 +9886,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -9081,7 +9895,8 @@
         "track": {
           "id": 451,
           "name": "Rudskogen Motorsenter"
-        }
+        },
+        "rainChance": 24
       },
       {
         "weekNum": 3,
@@ -9090,7 +9905,8 @@
           "id": 510,
           "name": "Algarve International Circuit",
           "config": "Grand Prix - Chicanes"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -9099,7 +9915,8 @@
           "id": 487,
           "name": "Circuit Zandvoort",
           "config": "Nationaal"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -9108,7 +9925,8 @@
           "id": 526,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Bike"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -9117,7 +9935,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 11
       },
       {
         "weekNum": 7,
@@ -9126,7 +9945,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -9135,7 +9955,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 40
       },
       {
         "weekNum": 9,
@@ -9144,7 +9965,8 @@
           "id": 252,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke 24h"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -9152,7 +9974,8 @@
         "track": {
           "id": 532,
           "name": "Thruxton Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -9161,7 +9984,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 67
       }
     ]
   },
@@ -9193,7 +10017,8 @@
           "id": 435,
           "name": "Watkins Glen International",
           "config": "Classic Boot"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -9202,7 +10027,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -9211,7 +10037,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -9220,7 +10047,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -9229,7 +10057,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -9238,7 +10067,8 @@
           "id": 445,
           "name": "Fuji International Speedway",
           "config": "No Chicane"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -9247,7 +10077,8 @@
           "id": 473,
           "name": "Circuito de Jerez - Ángel Nieto",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -9256,7 +10087,8 @@
           "id": 395,
           "name": "Hockenheimring Baden-Württemberg",
           "config": "Outer"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -9265,7 +10097,8 @@
           "id": 515,
           "name": "Circuito de Navarra",
           "config": "Speed Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -9274,7 +10107,8 @@
           "id": 192,
           "name": "Daytona International Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -9283,7 +10117,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -9292,7 +10127,8 @@
           "id": 341,
           "name": "Silverstone Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -9327,7 +10163,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -9336,7 +10173,8 @@
           "id": 524,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Classic Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -9345,7 +10183,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -9354,7 +10193,8 @@
           "id": 268,
           "name": "Circuit des 24 Heures du Mans",
           "config": "24 Heures du Mans"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -9363,7 +10203,8 @@
           "id": 195,
           "name": "Mobility Resort Motegi",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -9372,7 +10213,8 @@
           "id": 240,
           "name": "Autodromo Nazionale Monza",
           "config": "Combined without chicanes"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -9380,7 +10222,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -9388,7 +10231,8 @@
         "track": {
           "id": 144,
           "name": "Canadian Tire Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -9397,7 +10241,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -9406,7 +10251,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -9415,7 +10261,8 @@
           "id": 252,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke 24h"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -9424,7 +10271,8 @@
           "id": 185,
           "name": "Oulton Park Circuit",
           "config": "Intl w/no Chicanes"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -9455,7 +10303,8 @@
         "track": {
           "id": 271,
           "name": "The Bullring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -9463,7 +10312,8 @@
         "track": {
           "id": 256,
           "name": "Southern National Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -9471,7 +10321,8 @@
         "track": {
           "id": 94,
           "name": "The Milwaukee Mile"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -9479,7 +10330,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -9487,7 +10339,8 @@
         "track": {
           "id": 414,
           "name": "Hickory Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -9496,7 +10349,8 @@
           "id": 17,
           "name": "Lanier National Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -9504,7 +10358,8 @@
         "track": {
           "id": 286,
           "name": "Myrtle Beach Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -9513,7 +10368,8 @@
           "id": 366,
           "name": "North Wilkesboro Speedway",
           "config": "1987"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -9521,7 +10377,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -9530,7 +10387,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -9538,7 +10396,8 @@
         "track": {
           "id": 201,
           "name": "Langley Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -9546,7 +10405,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -9577,7 +10437,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -9585,7 +10446,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -9594,7 +10456,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -9602,16 +10465,18 @@
         "track": {
           "id": 414,
           "name": "Hickory Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
         "date": "2025-04-15",
         "track": {
-          "id": 288,
+          "id": 17,
           "name": "Lanier National Speedway",
-          "config": "Dirt"
-        }
+          "config": "Asphalt"
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -9620,7 +10485,8 @@
           "id": 11,
           "name": "Stafford Motor Speedway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -9629,7 +10495,8 @@
           "id": 493,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Asphalt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -9637,7 +10504,8 @@
         "track": {
           "id": 15,
           "name": "Concord Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -9645,7 +10513,8 @@
         "track": {
           "id": 286,
           "name": "Myrtle Beach Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -9653,7 +10522,8 @@
         "track": {
           "id": 256,
           "name": "Southern National Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -9661,7 +10531,8 @@
         "track": {
           "id": 201,
           "name": "Langley Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -9669,7 +10540,8 @@
         "track": {
           "id": 271,
           "name": "The Bullring"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -9701,7 +10573,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -9710,7 +10583,8 @@
           "id": 442,
           "name": "Bristol Motor Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -9718,7 +10592,8 @@
         "track": {
           "id": 373,
           "name": "Weedsport Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -9727,7 +10602,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -9735,7 +10611,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -9743,7 +10620,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -9751,7 +10629,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -9759,7 +10638,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -9768,7 +10648,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -9776,7 +10657,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -9784,7 +10666,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -9792,7 +10675,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -9824,7 +10708,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -9833,7 +10718,8 @@
           "id": 352,
           "name": "Lime Rock Park",
           "config": "Classic"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -9842,7 +10728,8 @@
           "id": 185,
           "name": "Oulton Park Circuit",
           "config": "Intl w/no Chicanes"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -9850,7 +10737,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -9859,7 +10747,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -9868,7 +10757,8 @@
           "id": 255,
           "name": "Nürburgring Grand-Prix-Strecke",
           "config": "BES/WEC"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -9877,7 +10767,8 @@
           "id": 9,
           "name": "Summit Point Raceway",
           "config": "Summit Point Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -9886,7 +10777,8 @@
           "id": 448,
           "name": "Indianapolis Motor Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -9895,7 +10787,8 @@
           "id": 232,
           "name": "Lucas Oil Indianapolis Raceway Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -9904,7 +10797,8 @@
           "id": 129,
           "name": "New Hampshire Motor Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -9912,7 +10806,8 @@
         "track": {
           "id": 532,
           "name": "Thruxton Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -9921,7 +10816,8 @@
           "id": 474,
           "name": "Circuito de Jerez - Ángel Nieto",
           "config": "Moto"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -9962,16 +10858,18 @@
           "id": 403,
           "name": "Red Bull Ring",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
         "date": "2025-03-25",
         "track": {
-          "id": 433,
+          "id": 434,
           "name": "Watkins Glen International",
-          "config": "Cup"
-        }
+          "config": "Boot"
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -9980,7 +10878,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -9989,7 +10888,8 @@
           "id": 498,
           "name": "Autodromo Internazionale del Mugello",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -9998,7 +10898,8 @@
           "id": 18,
           "name": "Road America",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -10007,7 +10908,8 @@
           "id": 229,
           "name": "Circuit of the Americas",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -10016,7 +10918,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -10025,7 +10928,8 @@
           "id": 268,
           "name": "Circuit des 24 Heures du Mans",
           "config": "24 Heures du Mans"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -10034,7 +10938,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -10043,7 +10948,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -10052,7 +10958,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -10061,13 +10968,14 @@
           "id": 252,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke 24h"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
   "446": {
     "id": 446,
-    "name": "DIRTcar Street Stock Rookie Racing Series by MOZA",
+    "name": "DIRTcar Street Stock Rookie Racing Series",
     "category": "dirt_oval",
     "laps": 20,
     "duration": null,
@@ -10093,7 +11001,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -10102,7 +11011,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -10110,7 +11020,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -10119,7 +11030,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -10128,7 +11040,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -10136,7 +11049,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -10145,7 +11059,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -10154,7 +11069,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -10162,7 +11078,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -10171,7 +11088,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -10180,7 +11098,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -10188,7 +11107,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -10235,7 +11155,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -10244,7 +11165,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 37
       },
       {
         "weekNum": 2,
@@ -10253,7 +11175,8 @@
           "id": 444,
           "name": "Fuji International Speedway",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -10261,7 +11184,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 17
       },
       {
         "weekNum": 4,
@@ -10270,7 +11194,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -10279,7 +11204,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -10288,7 +11214,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 36
       },
       {
         "weekNum": 7,
@@ -10297,7 +11224,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -10306,7 +11234,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -10315,7 +11244,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 16
       },
       {
         "weekNum": 10,
@@ -10324,7 +11254,8 @@
           "id": 319,
           "name": "Detroit Grand Prix at Belle Isle",
           "config": "Belle Isle"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -10333,7 +11264,8 @@
           "id": 268,
           "name": "Circuit des 24 Heures du Mans",
           "config": "24 Heures du Mans"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -10380,7 +11312,8 @@
           "id": 498,
           "name": "Autodromo Internazionale del Mugello",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 40
       },
       {
         "weekNum": 1,
@@ -10389,7 +11322,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 27
       },
       {
         "weekNum": 2,
@@ -10398,7 +11332,8 @@
           "id": 501,
           "name": "Misano World Circuit Marco Simoncelli",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -10407,7 +11342,8 @@
           "id": 463,
           "name": "Circuit de Nevers Magny-Cours",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 55
       },
       {
         "weekNum": 4,
@@ -10416,7 +11352,8 @@
           "id": 345,
           "name": "Circuit de Barcelona Catalunya",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 18
       }
     ]
   },
@@ -10448,7 +11385,8 @@
           "id": 181,
           "name": "Oulton Park Circuit",
           "config": "Fosters"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -10457,7 +11395,8 @@
           "id": 439,
           "name": "Winton Motor Raceway",
           "config": "National Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -10466,7 +11405,8 @@
           "id": 9,
           "name": "Summit Point Raceway",
           "config": "Summit Point Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -10474,7 +11414,8 @@
         "track": {
           "id": 451,
           "name": "Rudskogen Motorsenter"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -10483,7 +11424,8 @@
           "id": 467,
           "name": "Virginia International Raceway",
           "config": "North Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -10491,7 +11433,8 @@
         "track": {
           "id": 489,
           "name": "Circuit de Lédenon"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -10500,7 +11443,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -10509,7 +11453,8 @@
           "id": 449,
           "name": "Motorsport Arena Oschersleben",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -10518,7 +11463,8 @@
           "id": 516,
           "name": "Circuito de Navarra",
           "config": "Speed Circuit - Medium"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -10527,7 +11473,8 @@
           "id": 167,
           "name": "Okayama International Circuit",
           "config": "Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -10536,7 +11483,8 @@
           "id": 352,
           "name": "Lime Rock Park",
           "config": "Classic"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -10545,7 +11493,8 @@
           "id": 202,
           "name": "Oran Park Raceway",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -10577,7 +11526,8 @@
           "id": 435,
           "name": "Watkins Glen International",
           "config": "Classic Boot"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -10586,7 +11536,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -10595,7 +11546,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -10604,7 +11556,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -10613,7 +11566,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -10622,7 +11576,8 @@
           "id": 445,
           "name": "Fuji International Speedway",
           "config": "No Chicane"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -10631,7 +11586,8 @@
           "id": 473,
           "name": "Circuito de Jerez - Ángel Nieto",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -10640,7 +11596,8 @@
           "id": 395,
           "name": "Hockenheimring Baden-Württemberg",
           "config": "Outer"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -10649,7 +11606,8 @@
           "id": 515,
           "name": "Circuito de Navarra",
           "config": "Speed Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -10658,7 +11616,8 @@
           "id": 192,
           "name": "Daytona International Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -10667,7 +11626,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -10676,7 +11636,8 @@
           "id": 341,
           "name": "Silverstone Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -10712,7 +11673,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -10721,7 +11683,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 74
       },
       {
         "weekNum": 2,
@@ -10730,7 +11693,8 @@
           "id": 444,
           "name": "Fuji International Speedway",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -10738,7 +11702,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -10747,7 +11712,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 12
       },
       {
         "weekNum": 5,
@@ -10756,7 +11722,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -10765,7 +11732,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -10774,7 +11742,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -10783,7 +11752,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 18
       },
       {
         "weekNum": 9,
@@ -10792,7 +11762,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -10801,7 +11772,8 @@
           "id": 319,
           "name": "Detroit Grand Prix at Belle Isle",
           "config": "Belle Isle"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -10810,7 +11782,8 @@
           "id": 268,
           "name": "Circuit des 24 Heures du Mans",
           "config": "24 Heures du Mans"
-        }
+        },
+        "rainChance": 20
       }
     ]
   },
@@ -10841,7 +11814,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -10850,7 +11824,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -10858,7 +11833,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -10866,7 +11842,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -10874,7 +11851,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -10882,7 +11860,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -10890,7 +11869,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -10898,7 +11878,8 @@
         "track": {
           "id": 274,
           "name": "Williams Grove Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -10907,7 +11888,8 @@
           "id": 320,
           "name": "Kokomo Speedway",
           "config": "Tires in"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -10915,7 +11897,8 @@
         "track": {
           "id": 446,
           "name": "Port Royal Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -10924,7 +11907,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -10932,7 +11916,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -10964,7 +11949,8 @@
           "id": 293,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Rallycross Long"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -10973,7 +11959,8 @@
           "id": 306,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -10982,7 +11969,8 @@
           "id": 385,
           "name": "Charlotte Motor Speedway",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -10991,7 +11979,8 @@
           "id": 296,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Rallycross Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -11000,7 +11989,8 @@
           "id": 306,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -11009,7 +11999,8 @@
           "id": 293,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Rallycross Long"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -11018,7 +12009,8 @@
           "id": 385,
           "name": "Charlotte Motor Speedway",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -11027,7 +12019,8 @@
           "id": 296,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Rallycross Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -11036,7 +12029,8 @@
           "id": 293,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Rallycross Long"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -11045,7 +12039,8 @@
           "id": 306,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -11054,7 +12049,8 @@
           "id": 385,
           "name": "Charlotte Motor Speedway",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -11063,7 +12059,8 @@
           "id": 296,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Rallycross Short"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -11095,7 +12092,8 @@
           "id": 385,
           "name": "Charlotte Motor Speedway",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -11104,7 +12102,8 @@
           "id": 322,
           "name": "Atlanta Motor Speedway",
           "config": "Rallycross Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -11113,7 +12112,8 @@
           "id": 295,
           "name": "Iowa Speedway",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -11122,7 +12122,8 @@
           "id": 293,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Rallycross Long"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -11131,7 +12132,8 @@
           "id": 290,
           "name": "Brands Hatch Circuit",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -11140,7 +12142,8 @@
           "id": 386,
           "name": "Circuit de Barcelona Catalunya",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -11149,7 +12152,8 @@
           "id": 306,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -11158,7 +12162,8 @@
           "id": 312,
           "name": "Sonoma Raceway",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -11167,7 +12172,8 @@
           "id": 358,
           "name": "Lånkebanen (Hell RX)",
           "config": "Hell Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -11176,7 +12182,8 @@
           "id": 296,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Rallycross Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -11185,7 +12192,8 @@
           "id": 323,
           "name": "Atlanta Motor Speedway",
           "config": "Rallycross Long"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -11194,7 +12202,8 @@
           "id": 304,
           "name": "Lucas Oil Indianapolis Raceway Park",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -11228,7 +12237,8 @@
           "id": 386,
           "name": "Circuit de Barcelona Catalunya",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -11237,7 +12247,8 @@
           "id": 296,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Rallycross Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -11246,7 +12257,8 @@
           "id": 427,
           "name": "Knockhill Racing Circuit",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -11255,7 +12267,8 @@
           "id": 290,
           "name": "Brands Hatch Circuit",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -11264,7 +12277,8 @@
           "id": 385,
           "name": "Charlotte Motor Speedway",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -11273,7 +12287,8 @@
           "id": 360,
           "name": "Lånkebanen (Hell RX)",
           "config": "Rallycross Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -11282,7 +12297,8 @@
           "id": 322,
           "name": "Atlanta Motor Speedway",
           "config": "Rallycross Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -11291,7 +12307,8 @@
           "id": 293,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Rallycross Long"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -11300,7 +12317,8 @@
           "id": 295,
           "name": "Iowa Speedway",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -11309,7 +12327,8 @@
           "id": 304,
           "name": "Lucas Oil Indianapolis Raceway Park",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -11318,7 +12337,8 @@
           "id": 306,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -11327,7 +12347,8 @@
           "id": 312,
           "name": "Sonoma Raceway",
           "config": "Rallycross"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -11358,7 +12379,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -11367,7 +12389,8 @@
           "id": 470,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Dirt Road Long"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -11375,7 +12398,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -11384,7 +12408,8 @@
           "id": 472,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Dirt Road"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -11392,7 +12417,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -11401,7 +12427,8 @@
           "id": 471,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Dirt Road Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -11410,7 +12437,8 @@
           "id": 470,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Dirt Road Long"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -11418,7 +12446,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -11427,7 +12456,8 @@
           "id": 472,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Dirt Road"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -11435,7 +12465,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -11444,7 +12475,8 @@
           "id": 471,
           "name": "Daytona Rallycross and Dirt Road",
           "config": "Dirt Road Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -11452,7 +12484,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -11484,7 +12517,8 @@
           "id": 383,
           "name": "Crandon International Raceway",
           "config": "Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -11492,7 +12526,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -11500,7 +12535,8 @@
         "track": {
           "id": 396,
           "name": "Bark River International Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -11509,7 +12545,8 @@
           "id": 382,
           "name": "Crandon International Raceway",
           "config": "Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -11517,7 +12554,8 @@
         "track": {
           "id": 334,
           "name": "Firebird Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -11525,7 +12563,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -11533,7 +12572,8 @@
         "track": {
           "id": 396,
           "name": "Bark River International Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -11542,7 +12582,8 @@
           "id": 383,
           "name": "Crandon International Raceway",
           "config": "Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -11550,7 +12591,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -11558,7 +12600,8 @@
         "track": {
           "id": 334,
           "name": "Firebird Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -11566,7 +12609,8 @@
         "track": {
           "id": 396,
           "name": "Bark River International Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -11575,7 +12619,8 @@
           "id": 382,
           "name": "Crandon International Raceway",
           "config": "Full"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -11607,7 +12652,8 @@
           "id": 382,
           "name": "Crandon International Raceway",
           "config": "Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -11615,7 +12661,8 @@
         "track": {
           "id": 396,
           "name": "Bark River International Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -11623,7 +12670,8 @@
         "track": {
           "id": 334,
           "name": "Firebird Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -11631,7 +12679,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -11640,7 +12689,8 @@
           "id": 383,
           "name": "Crandon International Raceway",
           "config": "Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -11648,7 +12698,8 @@
         "track": {
           "id": 396,
           "name": "Bark River International Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -11656,7 +12707,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -11664,7 +12716,8 @@
         "track": {
           "id": 334,
           "name": "Firebird Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -11673,7 +12726,8 @@
           "id": 382,
           "name": "Crandon International Raceway",
           "config": "Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -11681,7 +12735,8 @@
         "track": {
           "id": 396,
           "name": "Bark River International Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -11689,7 +12744,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -11698,7 +12754,8 @@
           "id": 383,
           "name": "Crandon International Raceway",
           "config": "Short"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -11730,7 +12787,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -11739,7 +12797,8 @@
           "id": 442,
           "name": "Bristol Motor Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -11747,7 +12806,8 @@
         "track": {
           "id": 373,
           "name": "Weedsport Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -11756,7 +12816,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -11764,7 +12825,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -11772,7 +12834,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -11780,7 +12843,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -11788,7 +12852,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -11797,7 +12862,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -11805,7 +12871,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -11813,7 +12880,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -11821,7 +12889,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -11853,7 +12922,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -11862,7 +12932,8 @@
           "id": 357,
           "name": "Texas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -11871,7 +12942,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -11879,7 +12951,8 @@
         "track": {
           "id": 277,
           "name": "Pocono Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -11887,7 +12960,8 @@
         "track": {
           "id": 276,
           "name": "Michigan International Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -11896,7 +12970,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -11905,7 +12980,8 @@
           "id": 418,
           "name": "Phoenix Raceway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -11913,7 +12989,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -11922,7 +12999,8 @@
           "id": 225,
           "name": "Auto Club Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -11931,7 +13009,8 @@
           "id": 371,
           "name": "Kentucky Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -11940,7 +13019,8 @@
           "id": 237,
           "name": "World Wide Technology Raceway (Gateway)",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -11948,7 +13028,8 @@
         "track": {
           "id": 384,
           "name": "iRacing Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -11957,7 +13038,8 @@
           "id": 20,
           "name": "Homestead Miami Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -11989,7 +13071,8 @@
           "id": 341,
           "name": "Silverstone Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -11998,7 +13081,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -12007,7 +13091,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 39
       },
       {
         "weekNum": 3,
@@ -12016,7 +13101,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -12025,7 +13111,8 @@
           "id": 184,
           "name": "Oulton Park Circuit",
           "config": "Intl w/out Brittens"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -12034,7 +13121,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 58
       },
       {
         "weekNum": 6,
@@ -12043,7 +13131,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -12052,7 +13141,8 @@
           "id": 192,
           "name": "Daytona International Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -12061,7 +13151,8 @@
           "id": 403,
           "name": "Red Bull Ring",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 67
       },
       {
         "weekNum": 9,
@@ -12070,7 +13161,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -12079,7 +13171,8 @@
           "id": 432,
           "name": "Watkins Glen International",
           "config": "Classic"
-        }
+        },
+        "rainChance": 29
       },
       {
         "weekNum": 11,
@@ -12088,7 +13181,8 @@
           "id": 252,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke 24h"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -12120,7 +13214,8 @@
           "id": 335,
           "name": "Charlotte Motor Speedway",
           "config": "Legends Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -12129,7 +13224,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -12137,7 +13233,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -12145,7 +13242,8 @@
         "track": {
           "id": 15,
           "name": "Concord Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -12153,7 +13251,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -12162,7 +13261,8 @@
           "id": 17,
           "name": "Lanier National Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -12171,7 +13271,8 @@
           "id": 335,
           "name": "Charlotte Motor Speedway",
           "config": "Legends Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -12180,7 +13281,8 @@
           "id": 161,
           "name": "Thompson Speedway Motorsports Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -12188,7 +13290,8 @@
         "track": {
           "id": 201,
           "name": "Langley Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -12197,7 +13300,8 @@
           "id": 17,
           "name": "Lanier National Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -12205,7 +13309,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -12214,7 +13319,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -12246,7 +13352,8 @@
           "id": 498,
           "name": "Autodromo Internazionale del Mugello",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -12255,7 +13362,8 @@
           "id": 501,
           "name": "Misano World Circuit Marco Simoncelli",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -12264,7 +13372,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -12273,7 +13382,8 @@
           "id": 250,
           "name": "Nürburgring Grand-Prix-Strecke",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -12282,7 +13392,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -12291,7 +13402,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -12300,7 +13412,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -12309,7 +13422,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -12318,7 +13432,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -12326,7 +13441,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -12335,7 +13451,8 @@
           "id": 349,
           "name": "Circuit de Barcelona Catalunya",
           "config": "Historic"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -12344,7 +13461,8 @@
           "id": 463,
           "name": "Circuit de Nevers Magny-Cours",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -12376,7 +13494,8 @@
           "id": 382,
           "name": "Crandon International Raceway",
           "config": "Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -12384,7 +13503,8 @@
         "track": {
           "id": 396,
           "name": "Bark River International Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -12392,7 +13512,8 @@
         "track": {
           "id": 334,
           "name": "Firebird Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -12400,7 +13521,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -12409,7 +13531,8 @@
           "id": 383,
           "name": "Crandon International Raceway",
           "config": "Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -12417,7 +13540,8 @@
         "track": {
           "id": 396,
           "name": "Bark River International Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -12425,7 +13549,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -12433,7 +13558,8 @@
         "track": {
           "id": 334,
           "name": "Firebird Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -12442,7 +13568,8 @@
           "id": 382,
           "name": "Crandon International Raceway",
           "config": "Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -12450,7 +13577,8 @@
         "track": {
           "id": 396,
           "name": "Bark River International Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -12458,7 +13586,8 @@
         "track": {
           "id": 332,
           "name": "Wild West Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -12467,7 +13596,8 @@
           "id": 383,
           "name": "Crandon International Raceway",
           "config": "Short"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -12503,7 +13633,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 19
       },
       {
         "weekNum": 1,
@@ -12512,7 +13643,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -12520,7 +13652,8 @@
         "track": {
           "id": 218,
           "name": "Circuit Gilles Villeneuve"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -12529,7 +13662,8 @@
           "id": 510,
           "name": "Algarve International Circuit",
           "config": "Grand Prix - Chicanes"
-        }
+        },
+        "rainChance": 56
       },
       {
         "weekNum": 4,
@@ -12538,7 +13672,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -12547,7 +13682,8 @@
           "id": 526,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Bike"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -12556,7 +13692,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 15
       },
       {
         "weekNum": 7,
@@ -12565,7 +13702,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -12574,7 +13712,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -12583,7 +13722,8 @@
           "id": 252,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke 24h"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -12592,7 +13732,8 @@
           "id": 319,
           "name": "Detroit Grand Prix at Belle Isle",
           "config": "Belle Isle"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -12601,7 +13742,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 21
       }
     ]
   },
@@ -12641,7 +13783,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -12650,7 +13793,8 @@
           "id": 510,
           "name": "Algarve International Circuit",
           "config": "Grand Prix - Chicanes"
-        }
+        },
+        "rainChance": 18
       },
       {
         "weekNum": 2,
@@ -12659,7 +13803,8 @@
           "id": 526,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Bike"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -12668,7 +13813,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -12677,7 +13823,8 @@
           "id": 252,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke 24h"
-        }
+        },
+        "rainChance": 34
       },
       {
         "weekNum": 5,
@@ -12686,7 +13833,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 24
       }
     ]
   },
@@ -12719,7 +13867,8 @@
           "id": 324,
           "name": "Tsukuba Circuit",
           "config": "2000 Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -12728,7 +13877,8 @@
           "id": 449,
           "name": "Motorsport Arena Oschersleben",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -12737,7 +13887,8 @@
           "id": 467,
           "name": "Virginia International Raceway",
           "config": "North Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -12745,7 +13896,8 @@
         "track": {
           "id": 451,
           "name": "Rudskogen Motorsenter"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -12754,7 +13906,8 @@
           "id": 167,
           "name": "Okayama International Circuit",
           "config": "Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -12762,7 +13915,8 @@
         "track": {
           "id": 489,
           "name": "Circuit de Lédenon"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -12771,7 +13925,8 @@
           "id": 353,
           "name": "Lime Rock Park",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -12780,7 +13935,8 @@
           "id": 515,
           "name": "Circuito de Navarra",
           "config": "Speed Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -12789,7 +13945,8 @@
           "id": 9,
           "name": "Summit Point Raceway",
           "config": "Summit Point Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -12798,7 +13955,8 @@
           "id": 350,
           "name": "Charlotte Motor Speedway",
           "config": "Roval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -12807,7 +13965,8 @@
           "id": 181,
           "name": "Oulton Park Circuit",
           "config": "Fosters"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -12816,7 +13975,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -12847,7 +14007,8 @@
         "track": {
           "id": 152,
           "name": "Phillip Island Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -12856,7 +14017,8 @@
           "id": 498,
           "name": "Autodromo Internazionale del Mugello",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -12865,7 +14027,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -12874,7 +14037,8 @@
           "id": 250,
           "name": "Nürburgring Grand-Prix-Strecke",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -12883,7 +14047,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -12892,7 +14057,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -12901,7 +14067,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -12909,7 +14076,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -12918,7 +14086,8 @@
           "id": 349,
           "name": "Circuit de Barcelona Catalunya",
           "config": "Historic"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -12926,7 +14095,8 @@
         "track": {
           "id": 218,
           "name": "Circuit Gilles Villeneuve"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -12935,7 +14105,8 @@
           "id": 403,
           "name": "Red Bull Ring",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -12944,7 +14115,8 @@
           "id": 341,
           "name": "Silverstone Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -12953,7 +14125,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 13,
@@ -12961,7 +14134,8 @@
         "track": {
           "id": 413,
           "name": "Hungaroring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 14,
@@ -12970,7 +14144,8 @@
           "id": 485,
           "name": "Circuit Zandvoort",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 15,
@@ -12979,7 +14154,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 16,
@@ -12988,7 +14164,8 @@
           "id": 475,
           "name": "MotorLand Aragón",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 17,
@@ -12997,7 +14174,8 @@
           "id": 444,
           "name": "Fuji International Speedway",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 18,
@@ -13006,7 +14184,8 @@
           "id": 229,
           "name": "Circuit of the Americas",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 19,
@@ -13015,7 +14194,8 @@
           "id": 473,
           "name": "Circuito de Jerez - Ángel Nieto",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 20,
@@ -13024,7 +14204,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 21,
@@ -13033,7 +14214,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 22,
@@ -13042,7 +14224,8 @@
           "id": 463,
           "name": "Circuit de Nevers Magny-Cours",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 23,
@@ -13051,7 +14234,8 @@
           "id": 390,
           "name": "Hockenheimring Baden-Württemberg",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -13082,7 +14266,8 @@
         "track": {
           "id": 152,
           "name": "Phillip Island Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -13091,7 +14276,8 @@
           "id": 498,
           "name": "Autodromo Internazionale del Mugello",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -13100,7 +14286,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -13109,7 +14296,8 @@
           "id": 250,
           "name": "Nürburgring Grand-Prix-Strecke",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -13118,7 +14306,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -13127,7 +14316,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -13136,7 +14326,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -13144,7 +14335,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -13153,7 +14345,8 @@
           "id": 349,
           "name": "Circuit de Barcelona Catalunya",
           "config": "Historic"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -13161,7 +14354,8 @@
         "track": {
           "id": 218,
           "name": "Circuit Gilles Villeneuve"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -13170,7 +14364,8 @@
           "id": 403,
           "name": "Red Bull Ring",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -13179,7 +14374,8 @@
           "id": 341,
           "name": "Silverstone Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -13188,7 +14384,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 13,
@@ -13196,7 +14393,8 @@
         "track": {
           "id": 413,
           "name": "Hungaroring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 14,
@@ -13205,7 +14403,8 @@
           "id": 485,
           "name": "Circuit Zandvoort",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 15,
@@ -13214,7 +14413,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 16,
@@ -13223,7 +14423,8 @@
           "id": 475,
           "name": "MotorLand Aragón",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 17,
@@ -13232,7 +14433,8 @@
           "id": 444,
           "name": "Fuji International Speedway",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 18,
@@ -13241,7 +14443,8 @@
           "id": 229,
           "name": "Circuit of the Americas",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 19,
@@ -13250,7 +14453,8 @@
           "id": 473,
           "name": "Circuito de Jerez - Ángel Nieto",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 20,
@@ -13259,7 +14463,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 21,
@@ -13268,7 +14473,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 22,
@@ -13277,7 +14483,8 @@
           "id": 463,
           "name": "Circuit de Nevers Magny-Cours",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 23,
@@ -13286,7 +14493,8 @@
           "id": 390,
           "name": "Hockenheimring Baden-Württemberg",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -13318,7 +14526,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -13327,7 +14536,8 @@
           "id": 180,
           "name": "Oulton Park Circuit",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -13335,7 +14545,8 @@
         "track": {
           "id": 152,
           "name": "Phillip Island Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -13344,7 +14555,8 @@
           "id": 501,
           "name": "Misano World Circuit Marco Simoncelli",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -13353,7 +14565,8 @@
           "id": 166,
           "name": "Okayama International Circuit",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -13361,7 +14574,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -13369,7 +14583,8 @@
         "track": {
           "id": 532,
           "name": "Thruxton Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -13378,7 +14593,8 @@
           "id": 515,
           "name": "Circuito de Navarra",
           "config": "Speed Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -13387,7 +14603,8 @@
           "id": 18,
           "name": "Road America",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -13396,7 +14613,8 @@
           "id": 463,
           "name": "Circuit de Nevers Magny-Cours",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -13405,7 +14623,8 @@
           "id": 324,
           "name": "Tsukuba Circuit",
           "config": "2000 Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -13414,7 +14633,8 @@
           "id": 250,
           "name": "Nürburgring Grand-Prix-Strecke",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -13445,7 +14665,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -13453,7 +14674,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -13461,7 +14683,8 @@
         "track": {
           "id": 452,
           "name": "Lucas Oil Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -13469,7 +14692,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -13478,7 +14702,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -13486,7 +14711,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -13494,7 +14720,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -13502,7 +14729,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -13510,7 +14738,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -13519,7 +14748,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -13527,7 +14757,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -13535,7 +14766,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -13543,7 +14775,8 @@
         "track": {
           "id": 446,
           "name": "Port Royal Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 13,
@@ -13551,7 +14784,8 @@
         "track": {
           "id": 462,
           "name": "Lincoln Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 14,
@@ -13559,7 +14793,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 15,
@@ -13567,7 +14802,8 @@
         "track": {
           "id": 274,
           "name": "Williams Grove Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 16,
@@ -13575,7 +14811,8 @@
         "track": {
           "id": 452,
           "name": "Lucas Oil Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 17,
@@ -13584,7 +14821,8 @@
           "id": 320,
           "name": "Kokomo Speedway",
           "config": "Tires in"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 18,
@@ -13592,7 +14830,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 19,
@@ -13600,7 +14839,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 20,
@@ -13608,7 +14848,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 21,
@@ -13616,7 +14857,8 @@
         "track": {
           "id": 462,
           "name": "Lincoln Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 22,
@@ -13624,7 +14866,8 @@
         "track": {
           "id": 452,
           "name": "Lucas Oil Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 23,
@@ -13632,7 +14875,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 24,
@@ -13640,7 +14884,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 25,
@@ -13648,7 +14893,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 26,
@@ -13657,7 +14903,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 27,
@@ -13666,7 +14913,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 28,
@@ -13674,7 +14922,8 @@
         "track": {
           "id": 446,
           "name": "Port Royal Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 29,
@@ -13682,7 +14931,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 30,
@@ -13691,7 +14941,8 @@
           "id": 320,
           "name": "Kokomo Speedway",
           "config": "Tires in"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 31,
@@ -13699,7 +14950,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 32,
@@ -13707,7 +14959,8 @@
         "track": {
           "id": 274,
           "name": "Williams Grove Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 33,
@@ -13715,7 +14968,8 @@
         "track": {
           "id": 373,
           "name": "Weedsport Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 34,
@@ -13724,7 +14978,8 @@
           "id": 514,
           "name": "Kokomo Speedway",
           "config": "Tires out"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 35,
@@ -13732,7 +14987,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 36,
@@ -13741,7 +14997,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 37,
@@ -13749,7 +15006,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 38,
@@ -13757,7 +15015,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -13788,7 +15047,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -13796,7 +15056,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -13804,7 +15065,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -13812,7 +15074,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -13820,7 +15083,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -13829,7 +15093,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -13838,7 +15103,8 @@
           "id": 320,
           "name": "Kokomo Speedway",
           "config": "Tires in"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -13846,7 +15112,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -13854,7 +15121,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -13862,7 +15130,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -13870,7 +15139,8 @@
         "track": {
           "id": 446,
           "name": "Port Royal Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -13878,7 +15148,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -13886,7 +15157,8 @@
         "track": {
           "id": 274,
           "name": "Williams Grove Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 13,
@@ -13894,7 +15166,8 @@
         "track": {
           "id": 462,
           "name": "Lincoln Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 14,
@@ -13902,7 +15175,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 15,
@@ -13910,7 +15184,8 @@
         "track": {
           "id": 373,
           "name": "Weedsport Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 16,
@@ -13918,7 +15193,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 17,
@@ -13926,7 +15202,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 18,
@@ -13934,7 +15211,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 19,
@@ -13942,7 +15220,8 @@
         "track": {
           "id": 452,
           "name": "Lucas Oil Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 20,
@@ -13951,7 +15230,8 @@
           "id": 514,
           "name": "Kokomo Speedway",
           "config": "Tires out"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 21,
@@ -13959,7 +15239,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 22,
@@ -13967,7 +15248,8 @@
         "track": {
           "id": 274,
           "name": "Williams Grove Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 23,
@@ -13975,7 +15257,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 24,
@@ -13983,7 +15266,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 25,
@@ -13992,7 +15276,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 26,
@@ -14000,7 +15285,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 27,
@@ -14008,7 +15294,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 28,
@@ -14017,7 +15304,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 29,
@@ -14025,7 +15313,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 30,
@@ -14033,7 +15322,8 @@
         "track": {
           "id": 446,
           "name": "Port Royal Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 31,
@@ -14041,7 +15331,8 @@
         "track": {
           "id": 274,
           "name": "Williams Grove Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 32,
@@ -14049,7 +15340,8 @@
         "track": {
           "id": 462,
           "name": "Lincoln Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 33,
@@ -14057,7 +15349,8 @@
         "track": {
           "id": 452,
           "name": "Lucas Oil Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 34,
@@ -14065,7 +15358,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 35,
@@ -14073,7 +15367,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 36,
@@ -14081,7 +15376,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -14118,7 +15414,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -14127,7 +15424,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -14135,7 +15433,8 @@
         "track": {
           "id": 218,
           "name": "Circuit Gilles Villeneuve"
-        }
+        },
+        "rainChance": 46
       },
       {
         "weekNum": 3,
@@ -14144,7 +15443,8 @@
           "id": 510,
           "name": "Algarve International Circuit",
           "config": "Grand Prix - Chicanes"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -14153,7 +15453,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -14162,7 +15463,8 @@
           "id": 526,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Bike"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -14171,7 +15473,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 68
       },
       {
         "weekNum": 7,
@@ -14180,7 +15483,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -14189,7 +15493,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -14198,7 +15503,8 @@
           "id": 252,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke 24h"
-        }
+        },
+        "rainChance": 20
       },
       {
         "weekNum": 10,
@@ -14207,7 +15513,8 @@
           "id": 319,
           "name": "Detroit Grand Prix at Belle Isle",
           "config": "Belle Isle"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -14216,7 +15523,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 47
       }
     ]
   },
@@ -14251,7 +15559,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 27
       },
       {
         "weekNum": 1,
@@ -14260,7 +15569,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -14268,7 +15578,8 @@
         "track": {
           "id": 451,
           "name": "Rudskogen Motorsenter"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -14277,7 +15588,8 @@
           "id": 510,
           "name": "Algarve International Circuit",
           "config": "Grand Prix - Chicanes"
-        }
+        },
+        "rainChance": 24
       },
       {
         "weekNum": 4,
@@ -14286,7 +15598,8 @@
           "id": 487,
           "name": "Circuit Zandvoort",
           "config": "Nationaal"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -14295,7 +15608,8 @@
           "id": 526,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Bike"
-        }
+        },
+        "rainChance": 14
       },
       {
         "weekNum": 6,
@@ -14304,7 +15618,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -14313,7 +15628,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -14322,7 +15638,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 29
       },
       {
         "weekNum": 9,
@@ -14331,7 +15648,8 @@
           "id": 252,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke 24h"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -14339,7 +15657,8 @@
         "track": {
           "id": 532,
           "name": "Thruxton Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -14348,7 +15667,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -14380,7 +15700,8 @@
           "id": 449,
           "name": "Motorsport Arena Oschersleben",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -14389,7 +15710,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -14398,7 +15720,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -14407,7 +15730,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -14415,7 +15739,8 @@
         "track": {
           "id": 219,
           "name": "Mount Panorama Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -14424,7 +15749,8 @@
           "id": 166,
           "name": "Okayama International Circuit",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -14433,7 +15759,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -14442,7 +15769,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -14450,7 +15778,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -14459,7 +15788,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -14468,7 +15798,8 @@
           "id": 185,
           "name": "Oulton Park Circuit",
           "config": "Intl w/no Chicanes"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -14477,7 +15808,8 @@
           "id": 483,
           "name": "Chicago Street Course",
           "config": "2023 Cup"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -14509,7 +15841,8 @@
           "id": 353,
           "name": "Lime Rock Park",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 62
       },
       {
         "weekNum": 1,
@@ -14518,7 +15851,8 @@
           "id": 499,
           "name": "Autodromo Internazionale del Mugello",
           "config": "Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -14527,7 +15861,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -14536,7 +15871,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 12
       },
       {
         "weekNum": 4,
@@ -14545,7 +15881,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -14554,7 +15891,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -14563,7 +15901,8 @@
           "id": 515,
           "name": "Circuito de Navarra",
           "config": "Speed Circuit"
-        }
+        },
+        "rainChance": 19
       },
       {
         "weekNum": 7,
@@ -14571,7 +15910,8 @@
         "track": {
           "id": 219,
           "name": "Mount Panorama Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -14580,7 +15920,8 @@
           "id": 342,
           "name": "Silverstone Circuit",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -14589,7 +15930,8 @@
           "id": 184,
           "name": "Oulton Park Circuit",
           "config": "Intl w/out Brittens"
-        }
+        },
+        "rainChance": 58
       },
       {
         "weekNum": 10,
@@ -14598,7 +15940,8 @@
           "id": 527,
           "name": "Cadwell Park Circuit",
           "config": "Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -14607,7 +15950,8 @@
           "id": 192,
           "name": "Daytona International Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -14638,7 +15982,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -14646,7 +15991,8 @@
         "track": {
           "id": 274,
           "name": "Williams Grove Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -14654,7 +16000,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -14662,7 +16009,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -14671,7 +16019,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -14679,7 +16028,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -14688,7 +16038,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -14696,7 +16047,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -14704,7 +16056,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -14712,7 +16065,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -14720,7 +16074,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -14728,7 +16083,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -14760,7 +16116,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -14768,7 +16125,8 @@
         "track": {
           "id": 513,
           "name": "Millbridge Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -14776,7 +16134,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -14784,7 +16143,8 @@
         "track": {
           "id": 331,
           "name": "Chili Bowl"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -14792,7 +16152,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -14801,7 +16162,8 @@
           "id": 514,
           "name": "Kokomo Speedway",
           "config": "Tires out"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -14809,7 +16171,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -14817,7 +16180,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -14825,7 +16189,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -14833,7 +16198,8 @@
         "track": {
           "id": 452,
           "name": "Lucas Oil Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -14842,7 +16208,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -14850,7 +16217,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -14881,7 +16249,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -14889,7 +16258,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -14897,7 +16267,8 @@
         "track": {
           "id": 452,
           "name": "Lucas Oil Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -14906,7 +16277,8 @@
           "id": 320,
           "name": "Kokomo Speedway",
           "config": "Tires in"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -14914,7 +16286,8 @@
         "track": {
           "id": 314,
           "name": "The Dirt Track at Charlotte"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -14922,7 +16295,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -14930,7 +16304,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -14939,7 +16314,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -14947,7 +16323,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -14955,7 +16332,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -14963,7 +16341,8 @@
         "track": {
           "id": 446,
           "name": "Port Royal Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -14971,7 +16350,8 @@
         "track": {
           "id": 279,
           "name": "Volusia Speedway Park"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -15002,7 +16382,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -15010,7 +16391,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -15018,7 +16400,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -15027,7 +16410,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -15035,7 +16419,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -15043,7 +16428,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -15051,7 +16437,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -15059,7 +16446,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -15068,7 +16456,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -15076,7 +16465,8 @@
         "track": {
           "id": 373,
           "name": "Weedsport Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -15085,7 +16475,8 @@
           "id": 442,
           "name": "Bristol Motor Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -15094,7 +16485,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -15126,7 +16518,8 @@
           "id": 185,
           "name": "Oulton Park Circuit",
           "config": "Intl w/no Chicanes"
-        }
+        },
+        "rainChance": 30
       },
       {
         "weekNum": 1,
@@ -15135,7 +16528,8 @@
           "id": 166,
           "name": "Okayama International Circuit",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -15143,7 +16537,8 @@
         "track": {
           "id": 532,
           "name": "Thruxton Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -15151,7 +16546,8 @@
         "track": {
           "id": 451,
           "name": "Rudskogen Motorsenter"
-        }
+        },
+        "rainChance": 11
       },
       {
         "weekNum": 4,
@@ -15160,7 +16556,8 @@
           "id": 234,
           "name": "Donington Park Racing Circuit",
           "config": "National"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -15169,7 +16566,8 @@
           "id": 352,
           "name": "Lime Rock Park",
           "config": "Classic"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -15178,7 +16576,8 @@
           "id": 449,
           "name": "Motorsport Arena Oschersleben",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 26
       },
       {
         "weekNum": 7,
@@ -15187,7 +16586,8 @@
           "id": 8,
           "name": "Summit Point Raceway",
           "config": "Jefferson Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -15196,7 +16596,8 @@
           "id": 439,
           "name": "Winton Motor Raceway",
           "config": "National Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -15205,7 +16606,8 @@
           "id": 324,
           "name": "Tsukuba Circuit",
           "config": "2000 Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -15214,7 +16616,8 @@
           "id": 146,
           "name": "Brands Hatch Circuit",
           "config": "Indy"
-        }
+        },
+        "rainChance": 40
       },
       {
         "weekNum": 11,
@@ -15223,7 +16626,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -15255,7 +16659,8 @@
           "id": 181,
           "name": "Oulton Park Circuit",
           "config": "Fosters"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -15264,7 +16669,8 @@
           "id": 439,
           "name": "Winton Motor Raceway",
           "config": "National Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -15273,7 +16679,8 @@
           "id": 9,
           "name": "Summit Point Raceway",
           "config": "Summit Point Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -15281,7 +16688,8 @@
         "track": {
           "id": 451,
           "name": "Rudskogen Motorsenter"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -15290,7 +16698,8 @@
           "id": 467,
           "name": "Virginia International Raceway",
           "config": "North Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -15298,7 +16707,8 @@
         "track": {
           "id": 489,
           "name": "Circuit de Lédenon"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -15307,7 +16717,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -15316,7 +16727,8 @@
           "id": 449,
           "name": "Motorsport Arena Oschersleben",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -15325,7 +16737,8 @@
           "id": 516,
           "name": "Circuito de Navarra",
           "config": "Speed Circuit - Medium"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -15334,7 +16747,8 @@
           "id": 167,
           "name": "Okayama International Circuit",
           "config": "Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -15343,7 +16757,8 @@
           "id": 352,
           "name": "Lime Rock Park",
           "config": "Classic"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -15352,7 +16767,8 @@
           "id": 202,
           "name": "Oran Park Raceway",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -15384,7 +16800,8 @@
           "id": 527,
           "name": "Cadwell Park Circuit",
           "config": "Full"
-        }
+        },
+        "rainChance": 58
       },
       {
         "weekNum": 1,
@@ -15393,7 +16810,8 @@
           "id": 181,
           "name": "Oulton Park Circuit",
           "config": "Fosters"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -15402,7 +16820,8 @@
           "id": 145,
           "name": "Brands Hatch Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -15411,7 +16830,8 @@
           "id": 403,
           "name": "Red Bull Ring",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 33
       },
       {
         "weekNum": 4,
@@ -15420,7 +16840,8 @@
           "id": 423,
           "name": "Knockhill Racing Circuit",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -15429,7 +16850,8 @@
           "id": 485,
           "name": "Circuit Zandvoort",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -15438,7 +16860,8 @@
           "id": 146,
           "name": "Brands Hatch Circuit",
           "config": "Indy"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -15447,7 +16870,8 @@
           "id": 297,
           "name": "Snetterton Circuit",
           "config": "300"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -15456,7 +16880,8 @@
           "id": 343,
           "name": "Silverstone Circuit",
           "config": "National"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -15465,7 +16890,8 @@
           "id": 180,
           "name": "Oulton Park Circuit",
           "config": "International"
-        }
+        },
+        "rainChance": 31
       },
       {
         "weekNum": 10,
@@ -15473,7 +16899,8 @@
         "track": {
           "id": 532,
           "name": "Thruxton Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -15482,7 +16909,8 @@
           "id": 233,
           "name": "Donington Park Racing Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -15514,7 +16942,8 @@
           "id": 103,
           "name": "Las Vegas Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -15523,7 +16952,8 @@
           "id": 169,
           "name": "Iowa Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -15531,7 +16961,8 @@
         "track": {
           "id": 123,
           "name": "Chicagoland Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -15540,7 +16971,8 @@
           "id": 27,
           "name": "Daytona International Speedway",
           "config": "Oval - 2008"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -15548,7 +16980,8 @@
         "track": {
           "id": 31,
           "name": "Richmond Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -15557,7 +16990,8 @@
           "id": 225,
           "name": "Auto Club Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -15566,7 +17000,8 @@
           "id": 203,
           "name": "Rockingham Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -15575,7 +17010,8 @@
           "id": 48,
           "name": "Sonoma Raceway",
           "config": "NASCAR Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -15584,7 +17020,8 @@
           "id": 53,
           "name": "Atlanta Motor Speedway",
           "config": "Oval - 2008"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -15593,7 +17030,8 @@
           "id": 442,
           "name": "Bristol Motor Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -15602,7 +17040,8 @@
           "id": 522,
           "name": "Indianapolis Motor Speedway",
           "config": "NASCAR Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -15610,7 +17049,8 @@
         "track": {
           "id": 400,
           "name": "Nashville Superspeedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -15642,7 +17082,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 38
       },
       {
         "weekNum": 1,
@@ -15651,7 +17092,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -15659,7 +17101,8 @@
         "track": {
           "id": 218,
           "name": "Circuit Gilles Villeneuve"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -15668,7 +17111,8 @@
           "id": 510,
           "name": "Algarve International Circuit",
           "config": "Grand Prix - Chicanes"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -15677,7 +17121,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 57
       },
       {
         "weekNum": 5,
@@ -15686,7 +17131,8 @@
           "id": 526,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Bike"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -15695,7 +17141,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -15704,7 +17151,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 28
       },
       {
         "weekNum": 8,
@@ -15713,7 +17161,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -15722,7 +17171,8 @@
           "id": 252,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke 24h"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -15731,7 +17181,8 @@
           "id": 319,
           "name": "Detroit Grand Prix at Belle Isle",
           "config": "Belle Isle"
-        }
+        },
+        "rainChance": 2.5
       },
       {
         "weekNum": 11,
@@ -15740,7 +17191,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -15810,7 +17262,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -15861,7 +17314,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -15876,7 +17330,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -15891,7 +17346,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -15918,7 +17374,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -15949,7 +17406,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -15964,7 +17422,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -15983,7 +17442,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -15998,7 +17458,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -16029,7 +17490,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -16044,7 +17506,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -16059,7 +17522,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -16091,7 +17555,8 @@
           "id": 298,
           "name": "Snetterton Circuit",
           "config": "200"
-        }
+        },
+        "rainChance": 0.5
       },
       {
         "weekNum": 1,
@@ -16100,7 +17565,8 @@
           "id": 481,
           "name": "Willow Springs International Raceway",
           "config": "Big Willow"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -16109,7 +17575,8 @@
           "id": 350,
           "name": "Charlotte Motor Speedway",
           "config": "Roval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -16118,7 +17585,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 12
       },
       {
         "weekNum": 4,
@@ -16127,7 +17595,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -16135,7 +17604,8 @@
         "track": {
           "id": 144,
           "name": "Canadian Tire Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -16144,7 +17614,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 66
       },
       {
         "weekNum": 7,
@@ -16153,7 +17624,8 @@
           "id": 1,
           "name": "[Legacy] Lime Rock Park - 2008",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -16161,7 +17633,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -16170,7 +17643,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 45
       },
       {
         "weekNum": 10,
@@ -16179,7 +17653,8 @@
           "id": 21,
           "name": "Homestead Miami Speedway",
           "config": "Road Course A"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -16188,13 +17663,14 @@
           "id": 449,
           "name": "Motorsport Arena Oschersleben",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
   "535": {
     "id": 535,
-    "name": "GTE Sprint Series by CONSPIT ",
+    "name": "GTE Sprint Series",
     "category": "sports_car",
     "laps": null,
     "duration": 45,
@@ -16224,7 +17700,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -16233,7 +17710,8 @@
           "id": 192,
           "name": "Daytona International Speedway",
           "config": "Road Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -16242,7 +17720,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -16251,7 +17730,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -16260,7 +17740,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -16269,7 +17750,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -16277,7 +17759,8 @@
         "track": {
           "id": 219,
           "name": "Mount Panorama Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -16286,7 +17769,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -16295,7 +17779,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -16304,7 +17789,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -16313,7 +17799,8 @@
           "id": 252,
           "name": "Nürburgring Combined",
           "config": "Gesamtstrecke 24h"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -16322,7 +17809,8 @@
           "id": 319,
           "name": "Detroit Grand Prix at Belle Isle",
           "config": "Belle Isle"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -16355,7 +17843,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -16364,7 +17853,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -16373,7 +17863,8 @@
           "id": 18,
           "name": "Road America",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -16381,7 +17872,8 @@
         "track": {
           "id": 413,
           "name": "Hungaroring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -16390,7 +17882,8 @@
           "id": 195,
           "name": "Mobility Resort Motegi",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -16399,7 +17892,8 @@
           "id": 390,
           "name": "Hockenheimring Baden-Württemberg",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -16407,7 +17901,8 @@
         "track": {
           "id": 152,
           "name": "Phillip Island Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -16416,7 +17911,8 @@
           "id": 255,
           "name": "Nürburgring Grand-Prix-Strecke",
           "config": "BES/WEC"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -16425,7 +17921,8 @@
           "id": 463,
           "name": "Circuit de Nevers Magny-Cours",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -16434,7 +17931,8 @@
           "id": 341,
           "name": "Silverstone Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -16443,7 +17941,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -16452,7 +17951,8 @@
           "id": 524,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Classic Pits"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -16485,7 +17985,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -16494,7 +17995,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -16503,7 +18005,8 @@
           "id": 18,
           "name": "Road America",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -16511,7 +18014,8 @@
         "track": {
           "id": 413,
           "name": "Hungaroring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -16520,7 +18024,8 @@
           "id": 195,
           "name": "Mobility Resort Motegi",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -16529,7 +18034,8 @@
           "id": 390,
           "name": "Hockenheimring Baden-Württemberg",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -16537,7 +18043,8 @@
         "track": {
           "id": 152,
           "name": "Phillip Island Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -16546,7 +18053,8 @@
           "id": 255,
           "name": "Nürburgring Grand-Prix-Strecke",
           "config": "BES/WEC"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -16555,7 +18063,8 @@
           "id": 463,
           "name": "Circuit de Nevers Magny-Cours",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -16564,7 +18073,8 @@
           "id": 341,
           "name": "Silverstone Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -16573,7 +18083,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -16582,7 +18093,8 @@
           "id": 524,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Classic Pits"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -16635,7 +18147,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -16657,7 +18170,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -16683,7 +18197,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -16705,7 +18220,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -16727,7 +18243,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -16749,7 +18266,8 @@
         "track": {
           "id": 116,
           "name": "Talladega Superspeedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -16764,7 +18282,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -16787,7 +18306,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -16814,7 +18334,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -16837,7 +18358,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -16860,7 +18382,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -16883,7 +18406,8 @@
           "id": 191,
           "name": "Daytona International Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -16930,7 +18454,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 80
       },
       {
         "weekNum": 1,
@@ -16939,7 +18464,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -16948,7 +18474,8 @@
           "id": 444,
           "name": "Fuji International Speedway",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 23
       },
       {
         "weekNum": 3,
@@ -16956,7 +18483,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -16965,7 +18493,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -16974,7 +18503,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -16983,7 +18513,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -16992,7 +18523,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -17001,7 +18533,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 49
       },
       {
         "weekNum": 9,
@@ -17010,7 +18543,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -17019,7 +18553,8 @@
           "id": 319,
           "name": "Detroit Grand Prix at Belle Isle",
           "config": "Belle Isle"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -17028,7 +18563,8 @@
           "id": 268,
           "name": "Circuit des 24 Heures du Mans",
           "config": "24 Heures du Mans"
-        }
+        },
+        "rainChance": 62
       }
     ]
   },
@@ -17060,7 +18596,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -17069,7 +18606,8 @@
           "id": 324,
           "name": "Tsukuba Circuit",
           "config": "2000 Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -17078,7 +18616,8 @@
           "id": 444,
           "name": "Fuji International Speedway",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -17086,7 +18625,8 @@
         "track": {
           "id": 443,
           "name": "Sandown International Motor Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -17095,7 +18635,8 @@
           "id": 439,
           "name": "Winton Motor Raceway",
           "config": "National Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -17103,7 +18644,8 @@
         "track": {
           "id": 152,
           "name": "Phillip Island Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -17112,7 +18654,8 @@
           "id": 195,
           "name": "Mobility Resort Motegi",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -17121,7 +18664,8 @@
           "id": 202,
           "name": "Oran Park Raceway",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -17130,7 +18674,8 @@
           "id": 445,
           "name": "Fuji International Speedway",
           "config": "No Chicane"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -17138,7 +18683,8 @@
         "track": {
           "id": 219,
           "name": "Mount Panorama Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -17147,7 +18693,8 @@
           "id": 166,
           "name": "Okayama International Circuit",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -17156,7 +18703,8 @@
           "id": 176,
           "name": "Suzuka International Racing Course",
           "config": "West w/chicane"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -17188,7 +18736,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -17197,7 +18746,8 @@
           "id": 353,
           "name": "Lime Rock Park",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -17206,7 +18756,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -17215,7 +18766,8 @@
           "id": 397,
           "name": "Sonoma Raceway",
           "config": "Open Wheel 2012-2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -17224,7 +18776,8 @@
           "id": 465,
           "name": "Virginia International Raceway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -17233,7 +18786,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -17242,7 +18796,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -17251,7 +18806,8 @@
           "id": 9,
           "name": "Summit Point Raceway",
           "config": "Summit Point Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -17259,7 +18815,8 @@
         "track": {
           "id": 144,
           "name": "Canadian Tire Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -17268,7 +18825,8 @@
           "id": 46,
           "name": "Barber Motorsports Park",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -17277,7 +18835,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -17286,7 +18845,8 @@
           "id": 434,
           "name": "Watkins Glen International",
           "config": "Boot"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -17318,7 +18878,8 @@
           "id": 266,
           "name": "Autodromo Internazionale Enzo e Dino Ferrari",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -17327,7 +18888,8 @@
           "id": 449,
           "name": "Motorsport Arena Oschersleben",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -17335,7 +18897,8 @@
         "track": {
           "id": 413,
           "name": "Hungaroring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -17344,7 +18907,8 @@
           "id": 475,
           "name": "MotorLand Aragón",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -17353,7 +18917,8 @@
           "id": 297,
           "name": "Snetterton Circuit",
           "config": "300"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -17362,7 +18927,8 @@
           "id": 345,
           "name": "Circuit de Barcelona Catalunya",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -17371,7 +18937,8 @@
           "id": 234,
           "name": "Donington Park Racing Circuit",
           "config": "National"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -17379,7 +18946,8 @@
         "track": {
           "id": 489,
           "name": "Circuit de Lédenon"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -17388,7 +18956,8 @@
           "id": 390,
           "name": "Hockenheimring Baden-Württemberg",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -17397,7 +18966,8 @@
           "id": 473,
           "name": "Circuito de Jerez - Ángel Nieto",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -17405,7 +18975,8 @@
         "track": {
           "id": 451,
           "name": "Rudskogen Motorsenter"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -17414,7 +18985,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -17445,7 +19017,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -17454,7 +19027,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -17462,7 +19036,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -17471,7 +19046,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -17479,7 +19055,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -17488,7 +19065,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -17496,7 +19074,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -17505,7 +19084,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -17513,7 +19093,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -17522,7 +19103,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -17530,7 +19112,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -17539,7 +19122,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -17571,7 +19155,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 45
       },
       {
         "weekNum": 1,
@@ -17580,7 +19165,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -17589,7 +19175,8 @@
           "id": 18,
           "name": "Road America",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -17597,7 +19184,8 @@
         "track": {
           "id": 413,
           "name": "Hungaroring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -17606,7 +19194,8 @@
           "id": 195,
           "name": "Mobility Resort Motegi",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -17615,7 +19204,8 @@
           "id": 390,
           "name": "Hockenheimring Baden-Württemberg",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -17623,7 +19213,8 @@
         "track": {
           "id": 152,
           "name": "Phillip Island Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -17632,7 +19223,8 @@
           "id": 255,
           "name": "Nürburgring Grand-Prix-Strecke",
           "config": "BES/WEC"
-        }
+        },
+        "rainChance": 35
       },
       {
         "weekNum": 8,
@@ -17641,7 +19233,8 @@
           "id": 463,
           "name": "Circuit de Nevers Magny-Cours",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -17650,7 +19243,8 @@
           "id": 341,
           "name": "Silverstone Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -17658,7 +19252,8 @@
         "track": {
           "id": 219,
           "name": "Mount Panorama Circuit"
-        }
+        },
+        "rainChance": 38
       },
       {
         "weekNum": 11,
@@ -17667,7 +19262,8 @@
           "id": 524,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Classic Pits"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -17699,7 +19295,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -17708,7 +19305,8 @@
           "id": 509,
           "name": "Algarve International Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 24
       },
       {
         "weekNum": 2,
@@ -17717,7 +19315,8 @@
           "id": 18,
           "name": "Road America",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -17725,7 +19324,8 @@
         "track": {
           "id": 413,
           "name": "Hungaroring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -17734,7 +19334,8 @@
           "id": 195,
           "name": "Mobility Resort Motegi",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0.2
       },
       {
         "weekNum": 5,
@@ -17743,7 +19344,8 @@
           "id": 390,
           "name": "Hockenheimring Baden-Württemberg",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -17751,7 +19353,8 @@
         "track": {
           "id": 152,
           "name": "Phillip Island Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -17760,7 +19363,8 @@
           "id": 255,
           "name": "Nürburgring Grand-Prix-Strecke",
           "config": "BES/WEC"
-        }
+        },
+        "rainChance": 42
       },
       {
         "weekNum": 8,
@@ -17769,7 +19373,8 @@
           "id": 463,
           "name": "Circuit de Nevers Magny-Cours",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -17778,7 +19383,8 @@
           "id": 341,
           "name": "Silverstone Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -17786,7 +19392,8 @@
         "track": {
           "id": 219,
           "name": "Mount Panorama Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -17795,7 +19402,8 @@
           "id": 524,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Classic Pits"
-        }
+        },
+        "rainChance": 15
       }
     ]
   },
@@ -17834,7 +19442,8 @@
           "id": 514,
           "name": "Kokomo Speedway",
           "config": "Tires out"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -17849,7 +19458,8 @@
           "id": 514,
           "name": "Kokomo Speedway",
           "config": "Tires out"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -17863,7 +19473,8 @@
         "track": {
           "id": 513,
           "name": "Millbridge Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -17877,7 +19488,8 @@
         "track": {
           "id": 513,
           "name": "Millbridge Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -17892,7 +19504,8 @@
           "id": 497,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Mini Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -17907,7 +19520,8 @@
           "id": 497,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Mini Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -17921,7 +19535,8 @@
         "track": {
           "id": 331,
           "name": "Chili Bowl"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -17935,7 +19550,8 @@
         "track": {
           "id": 331,
           "name": "Chili Bowl"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -17949,7 +19565,8 @@
         "track": {
           "id": 513,
           "name": "Millbridge Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -17963,7 +19580,8 @@
         "track": {
           "id": 513,
           "name": "Millbridge Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -17977,7 +19595,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -17991,7 +19610,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -18023,7 +19643,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -18032,7 +19653,8 @@
           "id": 27,
           "name": "Daytona International Speedway",
           "config": "Oval - 2008"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -18040,7 +19662,8 @@
         "track": {
           "id": 31,
           "name": "Richmond Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -18049,7 +19672,8 @@
           "id": 442,
           "name": "Bristol Motor Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -18058,7 +19682,8 @@
           "id": 203,
           "name": "Rockingham Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -18067,7 +19692,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -18076,7 +19702,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -18085,7 +19712,8 @@
           "id": 366,
           "name": "North Wilkesboro Speedway",
           "config": "1987"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -18093,7 +19721,8 @@
         "track": {
           "id": 190,
           "name": "New Smyrna Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -18102,7 +19731,8 @@
           "id": 374,
           "name": "Nashville Fairgrounds Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -18110,7 +19740,8 @@
         "track": {
           "id": 286,
           "name": "Myrtle Beach Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -18119,13 +19750,14 @@
           "id": 161,
           "name": "Thompson Speedway Motorsports Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
   "557": {
     "id": 557,
-    "name": "BMW M Power Challenge - Fixed",
+    "name": "BMW M Power Challenge",
     "category": "sports_car",
     "laps": null,
     "duration": 15,
@@ -18151,7 +19783,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -18160,7 +19793,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -18169,7 +19803,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -18178,7 +19813,8 @@
           "id": 166,
           "name": "Okayama International Circuit",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -18187,7 +19823,8 @@
           "id": 247,
           "name": "Autodromo Nazionale Monza",
           "config": "Combined"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -18196,7 +19833,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -18205,7 +19843,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -18214,7 +19853,8 @@
           "id": 180,
           "name": "Oulton Park Circuit",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -18223,7 +19863,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -18231,7 +19872,8 @@
         "track": {
           "id": 532,
           "name": "Thruxton Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -18239,7 +19881,8 @@
         "track": {
           "id": 451,
           "name": "Rudskogen Motorsenter"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -18248,7 +19891,8 @@
           "id": 501,
           "name": "Misano World Circuit Marco Simoncelli",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -18279,7 +19923,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -18288,7 +19933,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -18296,7 +19942,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -18305,7 +19952,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -18313,7 +19961,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -18322,7 +19971,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -18330,7 +19980,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -18339,7 +19990,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -18347,7 +19999,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -18356,7 +20009,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -18364,7 +20018,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -18373,7 +20028,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -18414,7 +20070,8 @@
           "id": 95,
           "name": "Sebring International Raceway",
           "config": "International"
-        }
+        },
+        "rainChance": 100
       },
       {
         "weekNum": 1,
@@ -18423,7 +20080,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 100
       },
       {
         "weekNum": 2,
@@ -18432,7 +20090,8 @@
           "id": 523,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Grand Prix Pits"
-        }
+        },
+        "rainChance": 100
       },
       {
         "weekNum": 3,
@@ -18441,7 +20100,8 @@
           "id": 166,
           "name": "Okayama International Circuit",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 100
       },
       {
         "weekNum": 4,
@@ -18450,7 +20110,8 @@
           "id": 247,
           "name": "Autodromo Nazionale Monza",
           "config": "Combined"
-        }
+        },
+        "rainChance": 100
       },
       {
         "weekNum": 5,
@@ -18459,7 +20120,8 @@
           "id": 153,
           "name": "Mid-Ohio Sports Car Course",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 100
       },
       {
         "weekNum": 6,
@@ -18468,7 +20130,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 100
       },
       {
         "weekNum": 7,
@@ -18477,7 +20140,8 @@
           "id": 180,
           "name": "Oulton Park Circuit",
           "config": "International"
-        }
+        },
+        "rainChance": 100
       },
       {
         "weekNum": 8,
@@ -18486,7 +20150,8 @@
           "id": 239,
           "name": "Autodromo Nazionale Monza",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 100
       },
       {
         "weekNum": 9,
@@ -18494,7 +20159,8 @@
         "track": {
           "id": 532,
           "name": "Thruxton Circuit"
-        }
+        },
+        "rainChance": 100
       },
       {
         "weekNum": 10,
@@ -18502,7 +20168,8 @@
         "track": {
           "id": 451,
           "name": "Rudskogen Motorsenter"
-        }
+        },
+        "rainChance": 100
       },
       {
         "weekNum": 11,
@@ -18511,7 +20178,8 @@
           "id": 501,
           "name": "Misano World Circuit Marco Simoncelli",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 100
       }
     ]
   },
@@ -18543,7 +20211,8 @@
           "id": 207,
           "name": "Oran Park Raceway",
           "config": "North"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -18551,7 +20220,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -18560,7 +20230,8 @@
           "id": 467,
           "name": "Virginia International Raceway",
           "config": "North Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -18569,7 +20240,8 @@
           "id": 527,
           "name": "Cadwell Park Circuit",
           "config": "Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -18578,7 +20250,8 @@
           "id": 146,
           "name": "Brands Hatch Circuit",
           "config": "Indy"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -18587,7 +20260,8 @@
           "id": 354,
           "name": "Lime Rock Park",
           "config": "Chicanes"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -18596,7 +20270,8 @@
           "id": 327,
           "name": "Tsukuba Circuit",
           "config": "1000 Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -18605,7 +20280,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -18614,7 +20290,8 @@
           "id": 181,
           "name": "Oulton Park Circuit",
           "config": "Fosters"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -18623,7 +20300,8 @@
           "id": 9,
           "name": "Summit Point Raceway",
           "config": "Summit Point Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -18632,7 +20310,8 @@
           "id": 167,
           "name": "Okayama International Circuit",
           "config": "Short"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -18641,7 +20320,8 @@
           "id": 299,
           "name": "Snetterton Circuit",
           "config": "100"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -18673,7 +20353,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -18682,7 +20363,8 @@
           "id": 169,
           "name": "Iowa Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -18690,7 +20372,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -18699,7 +20382,8 @@
           "id": 198,
           "name": "Mobility Resort Motegi",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -18708,7 +20392,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -18716,7 +20401,8 @@
         "track": {
           "id": 286,
           "name": "Myrtle Beach Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -18724,7 +20410,8 @@
         "track": {
           "id": 256,
           "name": "Southern National Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -18732,7 +20419,8 @@
         "track": {
           "id": 248,
           "name": "Five Flags Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -18741,7 +20429,8 @@
           "id": 232,
           "name": "Lucas Oil Indianapolis Raceway Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -18750,7 +20439,8 @@
           "id": 17,
           "name": "Lanier National Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -18758,7 +20448,8 @@
         "track": {
           "id": 31,
           "name": "Richmond Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -18767,7 +20458,8 @@
           "id": 104,
           "name": "[Legacy] Phoenix Raceway - 2008",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -18799,7 +20491,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -18807,7 +20500,8 @@
         "track": {
           "id": 201,
           "name": "Langley Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -18816,7 +20510,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -18824,7 +20519,8 @@
         "track": {
           "id": 256,
           "name": "Southern National Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -18832,7 +20528,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -18840,7 +20537,8 @@
         "track": {
           "id": 15,
           "name": "Concord Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -18848,7 +20546,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -18857,7 +20556,8 @@
           "id": 17,
           "name": "Lanier National Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -18866,7 +20566,8 @@
           "id": 161,
           "name": "Thompson Speedway Motorsports Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -18875,7 +20576,8 @@
           "id": 339,
           "name": "Charlotte Motor Speedway",
           "config": "Oval - 2018"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -18883,7 +20585,8 @@
         "track": {
           "id": 201,
           "name": "Langley Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -18892,7 +20595,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -18924,7 +20628,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -18933,7 +20638,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -18941,7 +20647,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -18950,7 +20657,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -18959,7 +20667,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -18967,7 +20676,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -18976,7 +20686,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -18985,7 +20696,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -18993,7 +20705,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -19002,7 +20715,8 @@
           "id": 275,
           "name": "USA International Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -19011,7 +20725,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -19019,7 +20734,8 @@
         "track": {
           "id": 303,
           "name": "Limaland Motorsports Park"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -19051,7 +20767,8 @@
           "id": 449,
           "name": "Motorsport Arena Oschersleben",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -19060,7 +20777,8 @@
           "id": 9,
           "name": "Summit Point Raceway",
           "config": "Summit Point Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -19069,7 +20787,8 @@
           "id": 354,
           "name": "Lime Rock Park",
           "config": "Chicanes"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -19078,7 +20797,8 @@
           "id": 439,
           "name": "Winton Motor Raceway",
           "config": "National Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -19087,7 +20807,8 @@
           "id": 47,
           "name": "WeatherTech Raceway at Laguna Seca",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -19095,7 +20816,8 @@
         "track": {
           "id": 489,
           "name": "Circuit de Lédenon"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -19104,7 +20826,8 @@
           "id": 350,
           "name": "Charlotte Motor Speedway",
           "config": "Roval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -19113,7 +20836,8 @@
           "id": 180,
           "name": "Oulton Park Circuit",
           "config": "International"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -19122,7 +20846,8 @@
           "id": 324,
           "name": "Tsukuba Circuit",
           "config": "2000 Full"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -19131,7 +20856,8 @@
           "id": 467,
           "name": "Virginia International Raceway",
           "config": "North Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -19140,7 +20866,8 @@
           "id": 515,
           "name": "Circuito de Navarra",
           "config": "Speed Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -19149,7 +20876,8 @@
           "id": 166,
           "name": "Okayama International Circuit",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -19186,7 +20914,8 @@
           "id": 536,
           "name": "Portland International Raceway",
           "config": "Full Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -19194,7 +20923,8 @@
         "track": {
           "id": 218,
           "name": "Circuit Gilles Villeneuve"
-        }
+        },
+        "rainChance": 42
       },
       {
         "weekNum": 2,
@@ -19203,7 +20933,8 @@
           "id": 127,
           "name": "Road Atlanta",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -19212,7 +20943,8 @@
           "id": 168,
           "name": "Suzuka International Racing Course",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 40
       },
       {
         "weekNum": 4,
@@ -19221,7 +20953,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -19230,7 +20963,8 @@
           "id": 319,
           "name": "Detroit Grand Prix at Belle Isle",
           "config": "Belle Isle"
-        }
+        },
+        "rainChance": 16
       }
     ]
   },
@@ -19261,7 +20995,8 @@
         "track": {
           "id": 190,
           "name": "New Smyrna Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -19269,7 +21004,8 @@
         "track": {
           "id": 414,
           "name": "Hickory Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -19277,7 +21013,8 @@
         "track": {
           "id": 248,
           "name": "Five Flags Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -19286,7 +21023,8 @@
           "id": 500,
           "name": "Slinger Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -19295,7 +21033,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -19304,7 +21043,8 @@
           "id": 23,
           "name": "Irwindale Speedway",
           "config": "Outer"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -19313,7 +21053,8 @@
           "id": 366,
           "name": "North Wilkesboro Speedway",
           "config": "1987"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -19321,7 +21062,8 @@
         "track": {
           "id": 414,
           "name": "Hickory Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -19329,7 +21071,8 @@
         "track": {
           "id": 94,
           "name": "The Milwaukee Mile"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -19338,7 +21081,8 @@
           "id": 500,
           "name": "Slinger Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -19346,7 +21090,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -19355,7 +21100,8 @@
           "id": 11,
           "name": "Stafford Motor Speedway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -19364,7 +21110,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 13,
@@ -19373,7 +21120,8 @@
           "id": 232,
           "name": "Lucas Oil Indianapolis Raceway Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 14,
@@ -19381,7 +21129,8 @@
         "track": {
           "id": 12,
           "name": "Oxford Plains Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 15,
@@ -19389,7 +21138,8 @@
         "track": {
           "id": 271,
           "name": "The Bullring"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 16,
@@ -19398,7 +21148,8 @@
           "id": 493,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Asphalt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 17,
@@ -19406,7 +21157,8 @@
         "track": {
           "id": 286,
           "name": "Myrtle Beach Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 18,
@@ -19414,7 +21166,8 @@
         "track": {
           "id": 256,
           "name": "Southern National Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 19,
@@ -19423,7 +21176,8 @@
           "id": 374,
           "name": "Nashville Fairgrounds Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 20,
@@ -19431,7 +21185,8 @@
         "track": {
           "id": 190,
           "name": "New Smyrna Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 21,
@@ -19439,7 +21194,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 22,
@@ -19447,7 +21203,8 @@
         "track": {
           "id": 248,
           "name": "Five Flags Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -19478,7 +21235,8 @@
         "track": {
           "id": 190,
           "name": "New Smyrna Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -19486,7 +21244,8 @@
         "track": {
           "id": 414,
           "name": "Hickory Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -19494,7 +21253,8 @@
         "track": {
           "id": 14,
           "name": "South Boston Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -19503,7 +21263,8 @@
           "id": 161,
           "name": "Thompson Speedway Motorsports Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -19511,7 +21272,8 @@
         "track": {
           "id": 414,
           "name": "Hickory Motor Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -19520,7 +21282,8 @@
           "id": 11,
           "name": "Stafford Motor Speedway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -19529,7 +21292,8 @@
           "id": 16,
           "name": "USA International Speedway",
           "config": "Asphalt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -19538,7 +21302,8 @@
           "id": 366,
           "name": "North Wilkesboro Speedway",
           "config": "1987"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -19547,7 +21312,8 @@
           "id": 500,
           "name": "Slinger Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -19555,7 +21321,8 @@
         "track": {
           "id": 256,
           "name": "Southern National Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -19563,7 +21330,8 @@
         "track": {
           "id": 94,
           "name": "The Milwaukee Mile"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -19572,7 +21340,8 @@
           "id": 11,
           "name": "Stafford Motor Speedway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -19581,7 +21350,8 @@
           "id": 161,
           "name": "Thompson Speedway Motorsports Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 13,
@@ -19589,7 +21359,8 @@
         "track": {
           "id": 31,
           "name": "Richmond Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 14,
@@ -19598,7 +21369,8 @@
           "id": 518,
           "name": "Oswego Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 15,
@@ -19607,7 +21379,8 @@
           "id": 131,
           "name": "New Hampshire Motor Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 16,
@@ -19616,7 +21389,8 @@
           "id": 11,
           "name": "Stafford Motor Speedway",
           "config": "Full Course"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 17,
@@ -19625,7 +21399,8 @@
           "id": 232,
           "name": "Lucas Oil Indianapolis Raceway Park",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 18,
@@ -19633,7 +21408,8 @@
         "track": {
           "id": 33,
           "name": "Martinsville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 19,
@@ -19642,7 +21418,8 @@
           "id": 374,
           "name": "Nashville Fairgrounds Speedway",
           "config": "Oval"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 20,
@@ -19650,7 +21427,8 @@
         "track": {
           "id": 286,
           "name": "Myrtle Beach Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -19682,7 +21460,8 @@
           "id": 494,
           "name": "Kevin Harvick's Kern Raceway",
           "config": "Dirt Track"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -19691,7 +21470,8 @@
           "id": 442,
           "name": "Bristol Motor Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -19699,7 +21479,8 @@
         "track": {
           "id": 373,
           "name": "Weedsport Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -19708,7 +21489,8 @@
           "id": 520,
           "name": "Oswego Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -19716,7 +21498,8 @@
         "track": {
           "id": 344,
           "name": "Fairbury Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -19724,7 +21507,8 @@
         "track": {
           "id": 531,
           "name": "Huset's Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -19732,7 +21516,8 @@
         "track": {
           "id": 351,
           "name": "Lernerville Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -19740,7 +21525,8 @@
         "track": {
           "id": 273,
           "name": "Eldora Speedway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -19749,7 +21535,8 @@
           "id": 288,
           "name": "Lanier National Speedway",
           "config": "Dirt"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -19757,7 +21544,8 @@
         "track": {
           "id": 438,
           "name": "Federated Auto Parts Raceway at I-55"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -19765,7 +21553,8 @@
         "track": {
           "id": 305,
           "name": "Knoxville Raceway"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -19773,7 +21562,8 @@
         "track": {
           "id": 387,
           "name": "Cedar Lake Speedway"
-        }
+        },
+        "rainChance": 0
       }
     ]
   },
@@ -19805,7 +21595,8 @@
           "id": 524,
           "name": "Circuit de Spa-Francorchamps",
           "config": "Classic Pits"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 1,
@@ -19814,7 +21605,8 @@
           "id": 212,
           "name": "Autódromo José Carlos Pace",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 2,
@@ -19822,7 +21614,8 @@
         "track": {
           "id": 179,
           "name": "Long Beach Street Circuit"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 3,
@@ -19831,7 +21624,8 @@
           "id": 498,
           "name": "Autodromo Internazionale del Mugello",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 4,
@@ -19840,7 +21634,8 @@
           "id": 200,
           "name": "Circuit Zolder",
           "config": "Alternate"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 5,
@@ -19849,7 +21644,8 @@
           "id": 474,
           "name": "Circuito de Jerez - Ángel Nieto",
           "config": "Moto"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 6,
@@ -19857,7 +21653,8 @@
         "track": {
           "id": 144,
           "name": "Canadian Tire Motorsports Park"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 7,
@@ -19866,7 +21663,8 @@
           "id": 463,
           "name": "Circuit de Nevers Magny-Cours",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 8,
@@ -19875,7 +21673,8 @@
           "id": 145,
           "name": "Brands Hatch Circuit",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 9,
@@ -19884,7 +21683,8 @@
           "id": 249,
           "name": "Nürburgring Nordschleife",
           "config": "Industriefahrten"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 10,
@@ -19893,7 +21693,8 @@
           "id": 403,
           "name": "Red Bull Ring",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 11,
@@ -19902,7 +21703,8 @@
           "id": 485,
           "name": "Circuit Zandvoort",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 12,
@@ -19911,7 +21713,8 @@
           "id": 244,
           "name": "Autodromo Nazionale Monza",
           "config": "GP without first chicane"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 13,
@@ -19920,7 +21723,8 @@
           "id": 435,
           "name": "Watkins Glen International",
           "config": "Classic Boot"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 14,
@@ -19928,7 +21732,8 @@
         "track": {
           "id": 218,
           "name": "Circuit Gilles Villeneuve"
-        }
+        },
+        "rainChance": 0
       },
       {
         "weekNum": 15,
@@ -19937,7 +21742,8 @@
           "id": 353,
           "name": "Lime Rock Park",
           "config": "Grand Prix"
-        }
+        },
+        "rainChance": 0
       }
     ]
   }

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -30,6 +30,7 @@ export const useUiStorePersist = create(
       seasonShowOwned: true,
       seasonShowParticipation: false,
       seasonShowThisWeek: true,
+      seasonShowRain: true,
       seasonCategory: ECarCategories.all,
       shopVolumeDiscount: true,
       shopLoyaltyDiscount: false,
@@ -68,6 +69,9 @@ export const setSeasonShowParticipation = (value: boolean) =>
 export const setSeasonShowThisWeek = (value: boolean) =>
   useUiStorePersist.setState(() => ({ seasonShowThisWeek: value }));
 
+export const setSeasonShowRain = (value: boolean) =>
+  useUiStorePersist.setState(() => ({ seasonShowRain: value }));
+
 export const setSeasonCategory = (value: ECarCategories) =>
   useUiStorePersist.setState(() => ({ seasonCategory: value }));
 
@@ -103,6 +107,9 @@ export const useUi = () => {
   const seasonShowThisWeek = useUiStorePersist(
     (state) => state.seasonShowThisWeek,
   );
+  const seasonShowRain = useUiStorePersist(
+    (state) => state.seasonShowRain,
+  );
   const seasonCategory = useUiStorePersist((state) => state.seasonCategory);
   const shopVolumeDiscount = useUiStorePersist(
     (state) => state.shopVolumeDiscount,
@@ -122,6 +129,7 @@ export const useUi = () => {
     seasonShowOwned,
     seasonShowParticipation,
     seasonShowThisWeek,
+    seasonShowRain,
     seasonCategory,
     shopVolumeDiscount,
     shopLoyaltyDiscount,


### PR DESCRIPTION
Adds a raindrop icon in the top right corner of the cell for a week where there is a chance of rain:

<img width="307" alt="Screenshot 2025-04-11 at 09 26 22" src="https://github.com/user-attachments/assets/a6dca001-1cbb-48c3-8921-74f535c2681d" />


Hovering over the raindrop shows the percentage chance of rain:

<img width="301" alt="Screenshot 2025-04-11 at 09 27 03" src="https://github.com/user-attachments/assets/b86d267f-1070-4084-b8d0-6485698d5c27" />


Adds a setting to toggle the rain indicator on and off:

<img width="388" alt="Screenshot 2025-04-11 at 09 26 37" src="https://github.com/user-attachments/assets/754a3e75-da57-4143-b512-aacc9e4c7447" />

Addresses issue #9 