### PR TITLE
Fix for 'Export My Content' dialog immediately closing

### DIFF
--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -1,5 +1,6 @@
 import { Flex, Stack } from "@chakra-ui/react";
 import TransferContentDialog from "../export/tranfer-content-dialog";
+import ExportDialogGlobal from "../export/export-dialog-global";
 import MainContainer from "../main-container/main-container";
 import BottomNavBar from "../nav-bar/bottom-nav-bar";
 import NavBar from "../nav-bar/nav-bar";
@@ -35,6 +36,7 @@ function App() {
       <BottomNavBar hideFrom="md" />
 
       <TransferContentDialog />
+      <ExportDialogGlobal />
     </Flex>
   );
 }

--- a/src/components/export/export-dialog-global.tsx
+++ b/src/components/export/export-dialog-global.tsx
@@ -5,39 +5,33 @@ import {
   DialogHeader,
   DialogRoot,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
 import useScreenSize from "@/hooks/useScreenSize";
-import { DialogRootProps } from "@chakra-ui/react";
-import { lazy, Suspense, useEffect, useState } from "react";
+import { lazy, Suspense } from "react";
+import { create } from "zustand";
 import LoadingContainer from "../page/loading-container";
+
 const ExportContent = lazy(() => import("./export-content"));
 
-function ExportDialog({ children, ...rest }: DialogRootProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const { width } = useScreenSize();
+const useExportDialog = create<{ open: boolean }>(() => ({ open: false }));
 
-  useEffect(() => {
-    (document.activeElement as HTMLElement).blur();
-  }, [isOpen]);
+export const openExportDialog = () => useExportDialog.setState({ open: true });
+
+function ExportDialogGlobal() {
+  const { open } = useExportDialog();
+  const { width } = useScreenSize();
 
   return (
     <DialogRoot
       lazyMount
       unmountOnExit
-      open={isOpen}
-      onOpenChange={(e) => {
-        (document.activeElement as HTMLElement).blur();
-        setIsOpen(e.open);
-      }}
+      open={open}
+      onOpenChange={(e) => useExportDialog.setState({ open: e.open })}
       size={width.lg ? "xl" : width.md ? "lg" : "full"}
       scrollBehavior="inside"
       placement="center"
       motionPreset="slide-in-bottom"
-      {...rest}
     >
-      <DialogTrigger asChild>{children}</DialogTrigger>
-
       <DialogContent>
         <DialogHeader textAlign={"center"}>
           <DialogTitle>Export My Content</DialogTitle>
@@ -53,4 +47,4 @@ function ExportDialog({ children, ...rest }: DialogRootProps) {
   );
 }
 
-export default ExportDialog;
+export default ExportDialogGlobal;

--- a/src/components/nav-bar/more-menu-content.tsx
+++ b/src/components/nav-bar/more-menu-content.tsx
@@ -16,7 +16,7 @@ import { useLocation } from "wouter";
 import AboutDialog from "../about/about-dialog";
 import BMCIcon from "../bmc/icon";
 import ChangelogDialog from "../changelog/changelog-dialog";
-import ExportDialog from "../export/export-dialog";
+import { openExportDialog } from "../export/export-dialog-global";
 import HelpDialog from "../help/help-dialog";
 import PrivacyPolicyAnalog from "../privacy-policy/privacy-policy-dialog";
 import { useColorMode } from "../ui/color-mode";
@@ -76,9 +76,7 @@ function MoreMenuContent({ close }: { close: () => void }) {
         <BMCIcon />
       </MoreMenuItem>
       <Separator />
-      <ExportDialog>
-        <MoreMenuItem label="Export My Content" icon={faShareFromSquare} />
-      </ExportDialog>
+      <MoreMenuItem label="Export My Content" icon={faShareFromSquare} onClick={() => { close(); openExportDialog(); }} />
       <Separator />
       <MoreMenuItem label="Switch Language" icon={faLanguage} disabled />
       <Separator />

--- a/src/components/top-bar/user-dropdown.tsx
+++ b/src/components/top-bar/user-dropdown.tsx
@@ -6,7 +6,7 @@ import {
   faSun,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import ExportDialog from "../export/export-dialog";
+import { openExportDialog } from "../export/export-dialog-global";
 import { Avatar } from "../ui/avatar";
 import { useColorMode } from "../ui/color-mode";
 import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from "../ui/menu";
@@ -35,14 +35,12 @@ function UserDropdown() {
           </MenuItem>
         )} */}
 
-        <ExportDialog>
-          <MenuItem value="export" valueText="Export My Content">
-            <Flex justifyContent={"center"} w={"1rem"}>
-              <FontAwesomeIcon icon={faShareFromSquare} />
-            </Flex>
-            <Box flex="1">Export My Content</Box>
-          </MenuItem>
-        </ExportDialog>
+        <MenuItem value="export" valueText="Export My Content" onClick={openExportDialog}>
+          <Flex justifyContent={"center"} w={"1rem"}>
+            <FontAwesomeIcon icon={faShareFromSquare} />
+          </Flex>
+          <Box flex="1">Export My Content</Box>
+        </MenuItem>
 
         <MenuItem value="language" valueText="Language" disabled>
           <Flex justifyContent={"center"} w={"1rem"}>


### PR DESCRIPTION
Replace the `DialogTrigger` wrapper with a globally-mounted dialog managed by a Zustand store. The dialog now lives at the app root and is opened via `openExportDialog()` from both trigger sites (mobile menu and desktop dropdown).

This fixes the behaviour where the dialog closed immediately after it was opened.

Full disclosure: this code was written with the help of an AI agent (Kiro CLI / Claude 4.6 Opus).

Fixes #22 