### PR TITLE
Add "My Schedule" view showing the races the user plans to enter

### DIFF
--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -1,5 +1,6 @@
 import { Flex, Stack } from "@chakra-ui/react";
 import TransferContentDialog from "../export/tranfer-content-dialog";
+import ExportDialogGlobal from "../export/export-dialog-global";
 import MainContainer from "../main-container/main-container";
 import BottomNavBar from "../nav-bar/bottom-nav-bar";
 import NavBar from "../nav-bar/nav-bar";
@@ -35,6 +36,7 @@ function App() {
       <BottomNavBar hideFrom="md" />
 
       <TransferContentDialog />
+      <ExportDialogGlobal />
     </Flex>
   );
 }

--- a/src/components/export/export-content.tsx
+++ b/src/components/export/export-content.tsx
@@ -6,13 +6,14 @@ import { QRCodeSVG } from "qrcode.react";
 import { Button } from "../ui/button";
 
 function ExportContent() {
-  const { myCars, myTracks, wishCars, wishTracks, favoriteSeries } = useIr();
+  const { myCars, myTracks, wishCars, wishTracks, favoriteSeries, mySchedule } = useIr();
   const queryParams = {
     myCars: myCars.join("-"),
     myTracks: myTracks.join("-"),
     wishCars: wishCars.join("-"),
     wishTracks: wishTracks.join("-"),
     favoriteSeries: favoriteSeries.join("-"),
+    mySchedule: mySchedule.join(","),
   };
 
   const params = new URLSearchParams(queryParams).toString();
@@ -40,7 +41,7 @@ function ExportContent() {
         <QRCodeSVG
           value={url}
           size={220}
-          title={"Export My Content"}
+          title={"Export My Data"}
           marginSize={5}
           imageSettings={{
             src: "/my-racing-planner-icon.svg",

--- a/src/components/export/export-dialog-global.tsx
+++ b/src/components/export/export-dialog-global.tsx
@@ -34,7 +34,7 @@ function ExportDialogGlobal() {
     >
       <DialogContent>
         <DialogHeader textAlign={"center"}>
-          <DialogTitle>Export My Content</DialogTitle>
+          <DialogTitle>Export My Data</DialogTitle>
         </DialogHeader>
         <DialogBody px={{ base: 4, md: 10 }} textAlign={"justify"}>
           <Suspense fallback={<LoadingContainer />}>

--- a/src/components/export/export-dialog-global.tsx
+++ b/src/components/export/export-dialog-global.tsx
@@ -5,39 +5,33 @@ import {
   DialogHeader,
   DialogRoot,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
 import useScreenSize from "@/hooks/useScreenSize";
-import { DialogRootProps } from "@chakra-ui/react";
-import { lazy, Suspense, useEffect, useState } from "react";
+import { lazy, Suspense } from "react";
+import { create } from "zustand";
 import LoadingContainer from "../page/loading-container";
+
 const ExportContent = lazy(() => import("./export-content"));
 
-function ExportDialog({ children, ...rest }: DialogRootProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const { width } = useScreenSize();
+const useExportDialog = create<{ open: boolean }>(() => ({ open: false }));
 
-  useEffect(() => {
-    (document.activeElement as HTMLElement).blur();
-  }, [isOpen]);
+export const openExportDialog = () => useExportDialog.setState({ open: true });
+
+function ExportDialogGlobal() {
+  const { open } = useExportDialog();
+  const { width } = useScreenSize();
 
   return (
     <DialogRoot
       lazyMount
       unmountOnExit
-      open={isOpen}
-      onOpenChange={(e) => {
-        (document.activeElement as HTMLElement).blur();
-        setIsOpen(e.open);
-      }}
+      open={open}
+      onOpenChange={(e) => useExportDialog.setState({ open: e.open })}
       size={width.lg ? "xl" : width.md ? "lg" : "full"}
       scrollBehavior="inside"
       placement="center"
       motionPreset="slide-in-bottom"
-      {...rest}
     >
-      <DialogTrigger asChild>{children}</DialogTrigger>
-
       <DialogContent>
         <DialogHeader textAlign={"center"}>
           <DialogTitle>Export My Content</DialogTitle>
@@ -53,4 +47,4 @@ function ExportDialog({ children, ...rest }: DialogRootProps) {
   );
 }
 
-export default ExportDialog;
+export default ExportDialogGlobal;

--- a/src/components/export/useContentTransfer.ts
+++ b/src/components/export/useContentTransfer.ts
@@ -18,7 +18,8 @@ function useContentTransfer() {
       "myTracks" in params ||
       "wishCars" in params ||
       "wishTracks" in params ||
-      "favoriteSeries" in params);
+      "favoriteSeries" in params ||
+      "mySchedule" in params);
 
   const applyData = () => {
     if (!hasNewData) return;
@@ -42,8 +43,11 @@ function useContentTransfer() {
       ?.split("-")
       .filter(Boolean)
       .map((n) => parseInt(n));
+    const mySchedule = params.mySchedule
+      ?.split(",")
+      .filter(Boolean) ?? [];
 
-    setContentStore({ myCars, myTracks, wishCars, wishTracks, favoriteSeries });
+    setContentStore({ myCars, myTracks, wishCars, wishTracks, favoriteSeries, mySchedule });
     removeQueryParams();
   };
 

--- a/src/components/main-container/main-container.tsx
+++ b/src/components/main-container/main-container.tsx
@@ -11,6 +11,7 @@ const SeriesPage = lazy(() => import("../series/series-page"));
 const ShopPage = lazy(() => import("../shop-guide/shop-page"));
 const TracksPage = lazy(() => import("../content/tracks-page"));
 const HistoryPage = lazy(() => import("../history/history-page"));
+const SchedulePage = lazy(() => import("../schedule/schedule-page"));
 
 function MainContainer() {
   usePageTracking();
@@ -35,6 +36,7 @@ function MainContainer() {
           <Route path={ETabs.MySeries} component={SeriesPage} />
           <Route path={ETabs.MyCars} component={CarsPage} />
           <Route path={ETabs.MyTracks} component={TracksPage} />
+          <Route path={ETabs.MySchedule} component={SchedulePage} />
           <Route path={ETabs.ShopGuide} component={ShopPage} />
           <Route path={ETabs.History} component={HistoryPage} />
 

--- a/src/components/nav-bar/bottom-nav-bar.tsx
+++ b/src/components/nav-bar/bottom-nav-bar.tsx
@@ -2,6 +2,7 @@ import { ETabs } from "@/store/ui";
 import { For, HStack, StackProps } from "@chakra-ui/react";
 import {
   faCar,
+  faCalendarDays,
   faFlagCheckered,
   faRoad,
   faShoppingBag,
@@ -15,6 +16,7 @@ function BottomNavBar({ ...props }: StackProps) {
   const [location] = useLocation();
 
   const tabsAction = [
+    { label: "My Schedule", icon: faCalendarDays, index: ETabs.MySchedule },
     { label: "My Season", icon: faTableCellsLarge, index: ETabs.MySeason },
     { label: "My Series", icon: faFlagCheckered, index: ETabs.MySeries },
     location === ETabs.MyTracks

--- a/src/components/nav-bar/more-menu-content.tsx
+++ b/src/components/nav-bar/more-menu-content.tsx
@@ -16,7 +16,7 @@ import { useLocation } from "wouter";
 import AboutDialog from "../about/about-dialog";
 import BMCIcon from "../bmc/icon";
 import ChangelogDialog from "../changelog/changelog-dialog";
-import ExportDialog from "../export/export-dialog";
+import { openExportDialog } from "../export/export-dialog-global";
 import HelpDialog from "../help/help-dialog";
 import PrivacyPolicyAnalog from "../privacy-policy/privacy-policy-dialog";
 import { useColorMode } from "../ui/color-mode";
@@ -76,9 +76,7 @@ function MoreMenuContent({ close }: { close: () => void }) {
         <BMCIcon />
       </MoreMenuItem>
       <Separator />
-      <ExportDialog>
-        <MoreMenuItem label="Export My Content" icon={faShareFromSquare} />
-      </ExportDialog>
+      <MoreMenuItem label="Export My Content" icon={faShareFromSquare} onClick={() => { close(); openExportDialog(); }} />
       <Separator />
       <MoreMenuItem label="Switch Language" icon={faLanguage} disabled />
       <Separator />

--- a/src/components/nav-bar/more-menu-content.tsx
+++ b/src/components/nav-bar/more-menu-content.tsx
@@ -2,6 +2,7 @@ import { useNotifications } from "@/store/notifications";
 import { ETabs } from "@/store/ui";
 import { Group, Separator, Stack } from "@chakra-ui/react";
 import {
+  faCalendarDays,
   faChartLine,
   faCircleQuestion,
   faFileLines,
@@ -57,6 +58,15 @@ function MoreMenuContent({ close }: { close: () => void }) {
       </Group>
       <Separator />
       <MoreMenuItem
+        label="My Schedule"
+        icon={faCalendarDays}
+        onClick={() => {
+          close();
+          navigate(ETabs.MySchedule);
+        }}
+      />
+      <Separator />
+      <MoreMenuItem
         label="History"
         icon={faChartLine}
         onClick={() => {
@@ -76,7 +86,7 @@ function MoreMenuContent({ close }: { close: () => void }) {
         <BMCIcon />
       </MoreMenuItem>
       <Separator />
-      <MoreMenuItem label="Export My Content" icon={faShareFromSquare} onClick={() => { close(); openExportDialog(); }} />
+      <MoreMenuItem label="Export My Data" icon={faShareFromSquare} onClick={() => { close(); openExportDialog(); }} />
       <Separator />
       <MoreMenuItem label="Switch Language" icon={faLanguage} disabled />
       <Separator />

--- a/src/components/nav-bar/nav-bar.tsx
+++ b/src/components/nav-bar/nav-bar.tsx
@@ -3,6 +3,7 @@ import { ETabs } from "@/store/ui";
 import { For, Image, Stack, StackProps } from "@chakra-ui/react";
 import {
   faCar,
+  faCalendarDays,
   faChartLine,
   faFlagCheckered,
   faRoad,
@@ -16,6 +17,7 @@ import MoreMenuButton from "./more-menu-button";
 import NavBarButton from "./nav-bar-button";
 
 const tabsTop = [
+  { label: "My Schedule", icon: faCalendarDays, index: ETabs.MySchedule },
   { label: "My Season", icon: faTableCellsLarge, index: ETabs.MySeason },
   { label: "My Series", icon: faFlagCheckered, index: ETabs.MySeries },
   { label: "My Cars", icon: faCar, index: ETabs.MyCars },

--- a/src/components/schedule/schedule-page.tsx
+++ b/src/components/schedule/schedule-page.tsx
@@ -1,0 +1,251 @@
+import { toggleScheduleEntry, useIr } from "@/store/ir";
+import { useUi } from "@/store/ui";
+import { ETabs } from "@/store/ui";
+import { ownNurbCombined, wishNurbCombined } from "@/ir-data/utils/tracks";
+import { Box, Flex, Grid, HStack, IconButton, Link, List, Text, VStack } from "@chakra-ui/react";
+import { faCalendarDays, faGears, faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useLocation } from "wouter";
+import SERIES_JSON from "../../ir-data/series.json";
+import TRACKS_JSON from "../../ir-data/tracks.json";
+import LicenseBadge from "../badges/license-badge";
+import Page from "../page/page";
+import PageHeader from "../page/page-header";
+import { CloseButton } from "../ui/close-button";
+import { EmptyState } from "../ui/empty-state";
+import { PopoverContent, PopoverRoot, PopoverTrigger } from "../ui/popover";
+import getScheduleDescription from "../series/getScheduleDescription";
+import useSeason, { getPreviousTuesday, formatDate } from "../season/useSeason";
+import { getContentColorScale } from "@/utils/color";
+import ScheduleSettingsPopover from "./schedule-settings-popover";
+
+type WeekEntry = {
+  seriesId: number;
+  date: string;
+};
+
+function parseScheduleKey(key: string): WeekEntry {
+  const idx = key.indexOf("_");
+  return {
+    seriesId: Number(key.substring(0, idx)),
+    date: key.substring(idx + 1),
+  };
+}
+
+function getWeekNumber(date: string, allSeasonDates: string[]): number {
+  const idx = allSeasonDates.indexOf(date);
+  return idx >= 0 ? idx + 1 : 0;
+}
+
+function getTrackForWeek(seriesId: number, date: string) {
+  const series = SERIES_JSON[seriesId.toString() as keyof typeof SERIES_JSON];
+  if (!series) return null;
+  const week = series.weeks.find(
+    (w) => getPreviousTuesday(w.date) === date,
+  );
+  return week ?? null;
+}
+
+const todayStartDate = getPreviousTuesday(formatDate(new Date()));
+
+function SchedulePage() {
+  const { mySchedule, favoriteSeries, myTracks, wishTracks } = useIr();
+  const { seasonUseLocalTimezone, seasonShowThisWeek } = useUi();
+  const { weeksStartDates } = useSeason();
+  const [_, navigate] = useLocation();
+
+  // Parse and filter to only entries whose series is still in favorites
+  const entries = mySchedule
+    .map(parseScheduleKey)
+    .filter((e) => favoriteSeries.includes(e.seriesId));
+
+  // Group by date
+  const byDate = entries.reduce<Record<string, WeekEntry[]>>((acc, entry) => {
+    (acc[entry.date] ??= []).push(entry);
+    return acc;
+  }, {});
+
+  const sortedDates = Object.keys(byDate).sort();
+
+  const shortFormat: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
+
+  // Use all season weeks so every week gets a row
+  const allWeeks = weeksStartDates;
+
+  return (
+    <Page>
+      <PageHeader
+        title="My Schedule"
+        description="Your planned races for each week of the season"
+      />
+      <HStack mb={2}>
+        <PopoverRoot positioning={{ placement: "right-start" }}>
+          <PopoverTrigger asChild>
+            <IconButton
+              aria-label="Settings"
+              variant={"outline"}
+              size={"lg"}
+              bgColor={{ base: "bg.muted", _hover: "bg" }}
+              borderRadius={"md"}
+            >
+              <FontAwesomeIcon icon={faGears} />
+            </IconButton>
+          </PopoverTrigger>
+          <PopoverContent>
+            <ScheduleSettingsPopover />
+          </PopoverContent>
+        </PopoverRoot>
+      </HStack>
+      {allWeeks.length === 0 ? (
+        <Flex flex={1} borderRadius="md" bgColor="bg.muted" p={4} justifyContent="center">
+          <EmptyState
+            icon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
+            title="No series selected"
+            description="Select series and schedule races from the My Season grid"
+          >
+            <List.Root variant="marker">
+              <List.Item>
+                <Link onClick={() => navigate(ETabs.MySeason)}>
+                  Go to My Season to select races
+                </Link>
+              </List.Item>
+            </List.Root>
+          </EmptyState>
+        </Flex>
+      ) : (
+        <Flex direction="column" gap={3} overflow="auto" pb={4}>
+          {allWeeks.map((date) => {
+            const weekStart = new Date(date);
+            const weekEnd = new Date(weekStart);
+            weekEnd.setUTCDate(weekEnd.getUTCDate() + 7);
+            const thisWeek = seasonShowThisWeek && todayStartDate === date;
+            const weekEntries = byDate[date] ?? [];
+
+            return (
+              <Box
+                key={date}
+                borderRadius="md"
+                bgColor="bg.muted"
+                p={3}
+                borderWidth={thisWeek ? "2px" : "1px"}
+                borderColor={thisWeek ? "bg.inverted" : "border.muted"}
+              >
+                <HStack gap={2} mb={weekEntries.length > 0 ? 2 : 0}>
+                  <FontAwesomeIcon icon={faCalendarDays} />
+                  <Text fontWeight="bold">
+                    {weekStart.toLocaleDateString("en-US", shortFormat)}
+                    {" – "}
+                    {weekEnd.toLocaleDateString("en-US", shortFormat)}
+                  </Text>
+                  <Text fontSize="xs" opacity={0.7}>
+                    (week {getWeekNumber(date, weeksStartDates)})
+                  </Text>
+                  {thisWeek && (
+                    <Text fontSize="xs" fontWeight="bold" color="green.500">
+                      This week
+                    </Text>
+                  )}
+                </HStack>
+                {weekEntries.length === 0 ? (
+                  <Text fontSize="sm" color="fg.muted" mt={1}>
+                    No races selected for this week
+                  </Text>
+                ) : (
+                <Grid gap={3} templateColumns="repeat(auto-fill, minmax(350px, 1fr))">
+                  {weekEntries.map((entry) => {
+                    const series = SERIES_JSON[
+                      entry.seriesId.toString() as keyof typeof SERIES_JSON
+                    ];
+                    if (!series) return null;
+                    const week = getTrackForWeek(entry.seriesId, date);
+                    const schedule = getScheduleDescription(
+                      entry.seriesId,
+                      seasonUseLocalTimezone,
+                    );
+                    const rainChance = (week as any)?.rainChance ?? 0;
+
+                    const trackId = (week as any)?.track?.id;
+                    const track = trackId
+                      ? TRACKS_JSON[String(trackId) as keyof typeof TRACKS_JSON]
+                      : null;
+                    const free = !!(track as any)?.free;
+                    const owned = track
+                      ? myTracks.includes((track as any).sku) ||
+                        ownNurbCombined((track as any).id, myTracks)
+                      : false;
+                    const wish = track
+                      ? wishTracks.includes((track as any).sku) ||
+                        wishNurbCombined((track as any).id, wishTracks, myTracks)
+                      : false;
+                    const scale = getContentColorScale(free, owned, wish);
+
+                    return (
+                      <Box
+                        key={entry.seriesId}
+                        borderRadius="md"
+                        borderWidth="1px"
+                        borderColor={`${scale}.500`}
+                        bg={{ base: `${scale}.50`, _dark: `${scale}.800` }}
+                        color={{ base: `${scale}.600`, _dark: `${scale}.400` }}
+                        p={3}
+                        position="relative"
+                        minW="220px"
+                      >
+                        <CloseButton
+                          size="xs"
+                          position="absolute"
+                          top={1}
+                          right={1}
+                          onClick={() => toggleScheduleEntry(entry.seriesId, date)}
+                        />
+                        <VStack align="start" gap={1} pr={5}>
+                          <HStack gap={2} align="start">
+                            <LicenseBadge
+                              letter={series.license.letter}
+                              color={series.license.color}
+                              size="xs"
+                              mt="2px"
+                            >
+                              {series.license.letter}
+                            </LicenseBadge>
+                            <Text fontWeight="bold" fontSize="sm" lineClamp={2}>
+                              {series.name}
+                            </Text>
+                          </HStack>
+                          {week && (
+                            <Text fontSize="sm">
+                              {(week as any).track.name}
+                              {(week as any).track.config && ` (${(week as any).track.config})`}
+                            </Text>
+                          )}
+                          {series.switching && (week as any)?.cars?.length > 0 && (
+                            <Text fontSize="sm">
+                              🚗 {(week as any).cars.map((c: any) => c.name).join(", ")}
+                            </Text>
+                          )}
+                          {schedule && (
+                            <Text fontSize="xs">
+                              {schedule}
+                            </Text>
+                          )}
+                          {rainChance > 0 && (
+                            <Text fontSize="xs">
+                              💧 {rainChance}% chance of rain
+                            </Text>
+                          )}
+                        </VStack>
+                      </Box>
+                    );
+                  })}
+                </Grid>
+                )}
+              </Box>
+            );
+          })}
+        </Flex>
+      )}
+    </Page>
+  );
+}
+
+export default SchedulePage;

--- a/src/components/schedule/schedule-settings-popover.tsx
+++ b/src/components/schedule/schedule-settings-popover.tsx
@@ -1,0 +1,63 @@
+import {
+  setSeasonShowThisWeek,
+  setSeasonUseLocalTimezone,
+  useUi,
+} from "@/store/ui";
+import { For, VStack } from "@chakra-ui/react";
+import { Switch } from "../ui/switch";
+import { Tooltip } from "../ui/tooltip";
+
+function ScheduleSettingsPopover() {
+  const { seasonShowThisWeek, seasonUseLocalTimezone } = useUi();
+
+  const timezoneName =
+    Intl.DateTimeFormat().resolvedOptions().timeZone || "Local";
+
+  const settingsList = [
+    {
+      id: "scheduleThisWeek",
+      text: "Highlight current week",
+      tooltip: "Highlight current week row",
+      checked: seasonShowThisWeek,
+      setChecked: setSeasonShowThisWeek,
+    },
+    {
+      id: "scheduleLocalTimezone",
+      text: `Schedule with ${timezoneName} time`,
+      tooltip: "Convert race times from UTC to your local time zone",
+      checked: seasonUseLocalTimezone,
+      setChecked: setSeasonUseLocalTimezone,
+    },
+  ];
+
+  return (
+    <VStack alignItems={"start"} p={2}>
+      <For
+        each={settingsList}
+        children={(settings) => (
+          <Tooltip
+            lazyMount
+            unmountOnExit
+            key={settings.id}
+            content={settings.tooltip}
+            showArrow
+            positioning={{ placement: "top" }}
+            openDelay={200}
+            closeDelay={100}
+            ids={{ trigger: settings.id }}
+          >
+            <Switch
+              ids={{ root: settings.id }}
+              checked={settings.checked}
+              onCheckedChange={({ checked }) => settings.setChecked(checked)}
+            >
+              {settings.text}
+            </Switch>
+          </Tooltip>
+        )}
+      />
+    </VStack>
+  );
+}
+
+export default ScheduleSettingsPopover;

--- a/src/components/season/season-table-row-cell.tsx
+++ b/src/components/season/season-table-row-cell.tsx
@@ -1,23 +1,12 @@
+import { useIr, toggleScheduleEntry } from "@/store/ir";
 import { useUi } from "@/store/ui";
 import { Text } from "@chakra-ui/react";
+import { getContentColorScale } from "@/utils/color";
 import ContentCheckbox from "../content/content-checkbox";
 import SeasonTableCarsPopover from "./season-table-cars-popover";
 import SortableColumnCell from "./sortable-column-cell";
 import { Tooltip } from "../ui/tooltip";
 import { TSeriesDateMap } from "./useSeason";
-
-function getColorScale(
-  free: boolean,
-  seasonShowOwned: boolean,
-  owned: boolean,
-  seasonShowWishlist: boolean,
-  wish: boolean,
-) {
-  if (free) return "green";
-  if (seasonShowOwned && owned) return "teal";
-  if (seasonShowWishlist && wish) return "blue";
-  return "red";
-}
 
 function SeasonTableRowCell({
   seriesId,
@@ -57,6 +46,16 @@ function SeasonTableRowCell({
     seasonShowRain,
   } = useUi();
 
+  const { mySchedule } = useIr();
+  const scheduled = mySchedule.includes(`${seriesId}_${date}`);
+
+  const handleCellClick = (e: React.MouseEvent) => {
+    // Don't toggle if clicking on interactive children (checkbox, popover button)
+    const target = e.target as HTMLElement;
+    if (target.closest("input, button, label, [role='checkbox']")) return;
+    toggleScheduleEntry(seriesId, date);
+  };
+
   const cars =
     (seriesDateMap?.[seriesId as keyof typeof seriesDateMap]?.[
       `${date}_cars`
@@ -67,12 +66,10 @@ function SeasonTableRowCell({
       `${date}_rainChance`
     ] as number) || 0;
 
-  const scale = getColorScale(
+  const scale = getContentColorScale(
     free,
-    seasonShowOwned,
-    owned,
-    seasonShowWishlist,
-    wish,
+    seasonShowOwned && owned,
+    seasonShowWishlist && wish,
   );
   const color = { _dark: `${scale}.400`, base: `${scale}.600` };
   const bgColor = { base: `${scale}.50`, _dark: `${scale}.800` };
@@ -85,6 +82,9 @@ function SeasonTableRowCell({
       onMouseLeave={() => seasonHighlight && setHighlightTrack(-1)}
       bgColor={seasonHighlight && highlight ? bgColorHighlight : bgColor}
       color={color}
+      onClick={handleCellClick}
+      cursor="pointer"
+      boxShadow={scheduled ? "inset 0 0 0 1.5px var(--chakra-colors-fg-muted)" : undefined}
     >
       {seasonShowRain && rainChance > 0 && (
         <Tooltip

--- a/src/components/top-bar/user-dropdown.tsx
+++ b/src/components/top-bar/user-dropdown.tsx
@@ -6,7 +6,7 @@ import {
   faSun,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import ExportDialog from "../export/export-dialog";
+import { openExportDialog } from "../export/export-dialog-global";
 import { Avatar } from "../ui/avatar";
 import { useColorMode } from "../ui/color-mode";
 import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from "../ui/menu";
@@ -35,14 +35,12 @@ function UserDropdown() {
           </MenuItem>
         )} */}
 
-        <ExportDialog>
-          <MenuItem value="export" valueText="Export My Content">
-            <Flex justifyContent={"center"} w={"1rem"}>
-              <FontAwesomeIcon icon={faShareFromSquare} />
-            </Flex>
-            <Box flex="1">Export My Content</Box>
-          </MenuItem>
-        </ExportDialog>
+        <MenuItem value="export" valueText="Export My Content" onClick={openExportDialog}>
+          <Flex justifyContent={"center"} w={"1rem"}>
+            <FontAwesomeIcon icon={faShareFromSquare} />
+          </Flex>
+          <Box flex="1">Export My Content</Box>
+        </MenuItem>
 
         <MenuItem value="language" valueText="Language" disabled>
           <Flex justifyContent={"center"} w={"1rem"}>

--- a/src/components/top-bar/user-dropdown.tsx
+++ b/src/components/top-bar/user-dropdown.tsx
@@ -35,11 +35,11 @@ function UserDropdown() {
           </MenuItem>
         )} */}
 
-        <MenuItem value="export" valueText="Export My Content" onClick={openExportDialog}>
+        <MenuItem value="export" valueText="Export My Data" onClick={openExportDialog}>
           <Flex justifyContent={"center"} w={"1rem"}>
             <FontAwesomeIcon icon={faShareFromSquare} />
           </Flex>
-          <Box flex="1">Export My Content</Box>
+          <Box flex="1">Export My Data</Box>
         </MenuItem>
 
         <MenuItem value="language" valueText="Language" disabled>

--- a/src/store/ir.ts
+++ b/src/store/ir.ts
@@ -8,6 +8,7 @@ interface IMyContentStore {
   wishCars: number[];
   wishTracks: number[];
   favoriteSeries: number[];
+  mySchedule: string[];
 }
 
 export const useIrStore = create(
@@ -18,6 +19,7 @@ export const useIrStore = create(
       wishCars: [],
       wishTracks: [],
       favoriteSeries: [],
+      mySchedule: [],
     }),
     { name: "my-content" },
   ),
@@ -65,12 +67,22 @@ export const setFavoriteSeriesItem = (id: number, enabled: boolean) =>
 export const setFavoriteSeriesList = (list: number[]) =>
   useIrStore.setState(() => ({ favoriteSeries: list }));
 
+export const toggleScheduleEntry = (seriesId: number, date: string) => {
+  const key = `${seriesId}_${date}`;
+  useIrStore.setState((state: IMyContentStore) => ({
+    mySchedule: state.mySchedule.includes(key)
+      ? state.mySchedule.filter((k) => k !== key)
+      : [...state.mySchedule, key],
+  }));
+};
+
 export const useIr = () => {
   const myCars = useIrStore((state) => state.myCars);
   const myTracks = useIrStore((state) => state.myTracks);
   const wishCars = useIrStore((state) => state.wishCars);
   const wishTracks = useIrStore((state) => state.wishTracks);
   const favoriteSeriesRaw = useIrStore((state) => state.favoriteSeries);
+  const mySchedule = useIrStore((state) => state.mySchedule ?? []);
 
   const favoriteSeries = favoriteSeriesRaw.filter(
     (id) => !!SERIES_JSON[id.toString() as keyof typeof SERIES_JSON],
@@ -82,5 +94,6 @@ export const useIr = () => {
     wishCars,
     wishTracks,
     favoriteSeries,
+    mySchedule,
   };
 };

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -7,6 +7,7 @@ export enum ETabs {
   MySeries = "/series",
   MyCars = "/cars",
   MyTracks = "/tracks",
+  MySchedule = "/schedule",
   ShopGuide = "/checkout",
   History = "/history",
 }

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -36,3 +36,12 @@ export function lightenHexColor(hex: string, percentage: number): string {
   const toHex = (value: number) => value.toString(16).padStart(2, "0");
   return `#${toHex(newR)}${toHex(newG)}${toHex(newB)}`;
 }
+
+export type ContentColorScale = "green" | "teal" | "blue" | "red";
+
+export function getContentColorScale(free: boolean, owned: boolean, wish: boolean): ContentColorScale {
+  if (free) return "green";
+  if (owned) return "teal";
+  if (wish) return "blue";
+  return "red";
+}


### PR DESCRIPTION
## Introduction
I am _not_ expecting this PR to be merged. I'm creating it to get some feedback on the feature, namely:

1. Is there any interest in adding this feature at all?
2. Can the design, UX and implementation be improved?

## Background
The "My Season" view in Racing Planner shows all of the races for every series that the user selects. Many users (myself included) do not race all of the series in any particular week. I use the season view to see all the races that are available, and then I choose one or two series to race for each week of the season.

Currently there is no way in Racing Planner to see which series I have chosen for each week. I have to create a separate spreadsheet and copy over my choices.

This feature aims to address this issue by allowing the user to select the series they plan to race for each week of the season and view a schedule for the season showing their races for each week.

## Description
This PR adds a "My Schedule" view where the user can see the series they're planning to race each week of the season.

After selecting their content and series as normal, the user can click cells in the "My Season" view to indicate that they are planning to race them. These cells are added to the schedule. Selected cells are shown with a border:

<img width="526" height="380" alt="image" src="https://github.com/user-attachments/assets/313b4eb6-e6de-4c17-9ded-7a10edbd8570" />

After selecting cells in "My Season" the user can switch to the new "My Schedule" view to see a list of the series they are planning to race each week of the season:

<img width="1273" height="989" alt="image" src="https://github.com/user-attachments/assets/df1674cd-5d11-425e-a793-7f9311f13f62" />

## Notes
* This PR includes the changes from #23. Please ignore them
* It was written with the help of Kiro CLI / Claude Opus 4.6