### PR TITLE
Exclude week-off weeks from participation credit calculation

### DIFF
--- a/src/components/season/season-table-header-participation.tsx
+++ b/src/components/season/season-table-header-participation.tsx
@@ -15,7 +15,7 @@ function SeasonTableHeaderParticipation({
 }: {
   seriesTracks?: Record<string, number | number[]>;
 }) {
-  const { myTracks, wishTracks } = useIr();
+  const { myTracks, wishTracks, weekOffDates } = useIr();
   const { t } = useTranslation();
 
   const {
@@ -31,12 +31,13 @@ function SeasonTableHeaderParticipation({
       ),
     );
 
-    const tracks = Object.values(filteredTracks)
-      .map((trackId) => {
+    const tracks = Object.entries(filteredTracks)
+      .map((entry) => {
         const track =
           TRACKS_JSON[
-            (trackId as number).toString() as keyof typeof TRACKS_JSON
-          ];
+            (entry[1] as number).toString() as keyof typeof TRACKS_JSON
+          ] as TContent;
+        track.week = entry[0].toString();
         return track;
       })
       .filter(Boolean) as TContent[];
@@ -45,14 +46,18 @@ function SeasonTableHeaderParticipation({
 
     const ownedTracks = tracks.filter(
       (track) =>
-        track.free ||
-        myTracks.includes(track.sku) ||
-        ownNurbCombined(track.id, myTracks),
+        !weekOffDates.includes(track.week ?? "") && (
+          track.free ||
+          myTracks.includes(track.sku) ||
+          ownNurbCombined(track.id, myTracks)
+        )
     ).length;
 
     const wishedTracks = tracks.filter(
       (track) =>
-        wishTracks.includes(track.sku) || ownNurbCombined(track.id, wishTracks),
+        !weekOffDates.includes(track.week ?? "") && (
+          wishTracks.includes(track.sku) || ownNurbCombined(track.id, wishTracks)
+        )
     ).length;
 
     return {

--- a/src/ir-data/utils/types.ts
+++ b/src/ir-data/utils/types.ts
@@ -30,4 +30,5 @@ export type TContent = {
   logo?: string;
   skuGroup?: { [key: string | number]: string };
   group?: number;
+  week?: string;
 };


### PR DESCRIPTION
When a user deselects a week to mark it as a "week off", this change now excludes those tracks from the calculation of owned and wished tracks for a series when calculating the participation credit header values

Before:
<img width="2988" height="1652" alt="before" src="https://github.com/user-attachments/assets/f666807f-0f36-4e17-9c97-da9ae84ebc88" />

After: (note week 1 was marked as a week off and in the 2nd column it went from 8/8 to 7/8 owned).
<img width="2988" height="1652" alt="after" src="https://github.com/user-attachments/assets/2ca99585-cf59-4a8d-8392-4aa176151c29" />
